### PR TITLE
fix(gdn): correct sm_86 cooperative-launch residency limits

### DIFF
--- a/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
+++ b/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
@@ -26,25 +26,27 @@ struct RouteSpec {
     Bf16GdnGatingScheduleId schedule;
 };
 
-constexpr std::array<RouteSpec, 6> k27Routes{{
+constexpr std::array<RouteSpec, 5> k27Routes{{
     {{1, 1}, Bf16GdnGatingScheduleId::GemvPairedRows},
     {{2, 8}, Bf16GdnGatingScheduleId::SmallTSplit10},
-    // As token tiles double, halve SplitK. This keeps the cooperative grid near 192 CTAs instead
-    // of making T a launch limit. Once the unsplit grid has enough independent work, it also
-    // removes the cooperative-residency constraint.
-    {{9, 1024}, Bf16GdnGatingScheduleId::MmaCooperativeSplit8},
-    {{1025, 2048}, Bf16GdnGatingScheduleId::MmaCooperativeSplit4},
-    {{2049, 4096}, Bf16GdnGatingScheduleId::MmaCooperativeSplit2},
-    {{4097, kAnyCols}, Bf16GdnGatingScheduleId::MmaUnsplit},
+    // sm_86 has 82 SMs. Split8 (256 threads, 65 regs) admits 2 CTAs/SM -> 164 device-wide;
+    // split4/2 (512 threads, 74 regs) admit 1 CTA/SM -> 82. Grid is ceil(T/128)*3*SplitK, so
+    // split8 is legal to T<=768 and split2 to T<=1664. Split4 reaches the same 768 ceiling as
+    // split8 while doing less work per launch, so it is unreachable on this target.
+    {{9, 768}, Bf16GdnGatingScheduleId::MmaCooperativeSplit8},
+    {{769, 1664}, Bf16GdnGatingScheduleId::MmaCooperativeSplit2},
+    {{1665, kAnyCols}, Bf16GdnGatingScheduleId::MmaUnsplit},
 }};
 
 constexpr std::array<RouteSpec, 5> k35Routes{{
-    // The same progression keeps the long-range cooperative routes near 256 CTAs.
+    // Same progression, clamped to the sm_86 residency ceilings. Grid is ceil(T/64)*2*SplitK, so
+    // with 328 CTAs for split16 and 246 for split8/4/2 the legal ends are 640 / 960 / 1920 / 3904.
+    // The upstream bounds (1024 / 2048 / 4096) each land on 256 CTAs and exceed the 246 limit.
     {{1, 127}, Bf16GdnGatingScheduleId::MmaCooperativeSplit16},
-    {{128, 1024}, Bf16GdnGatingScheduleId::MmaCooperativeSplit8},
-    {{1025, 2048}, Bf16GdnGatingScheduleId::MmaCooperativeSplit4},
-    {{2049, 4096}, Bf16GdnGatingScheduleId::MmaCooperativeSplit2},
-    {{4097, kAnyCols}, Bf16GdnGatingScheduleId::MmaUnsplit},
+    {{128, 960}, Bf16GdnGatingScheduleId::MmaCooperativeSplit8},
+    {{961, 1920}, Bf16GdnGatingScheduleId::MmaCooperativeSplit4},
+    {{1921, 3904}, Bf16GdnGatingScheduleId::MmaCooperativeSplit2},
+    {{3905, kAnyCols}, Bf16GdnGatingScheduleId::MmaUnsplit},
 }};
 
 template <std::size_t N>
@@ -60,6 +62,60 @@ constexpr bool catalog_is_closed(const std::array<RouteSpec, N>& routes,
 
 static_assert(catalog_is_closed(k27Routes, kAnyCols));
 static_assert(catalog_is_closed(k35Routes, kAnyCols));
+
+// Device-wide resident-CTA budgets, measured on the sm_86 build. These are the single source of
+// truth: both the runtime residency predicates and the compile-time catalog guard below read them,
+// so a retuned constant cannot silently disagree with the route table it is meant to bound.
+constexpr std::int32_t resident_ctas_27(Bf16GdnGatingScheduleId schedule) noexcept {
+    return schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit8 ? 164 : 82;
+}
+
+constexpr std::int32_t resident_ctas_35(Bf16GdnGatingScheduleId schedule) noexcept {
+    if (schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit32) { return 164; }
+    if (schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit16) { return 328; }
+    return 246;
+}
+
+// Zero marks a schedule that is not launched cooperatively and therefore carries no residency
+// constraint at all.
+constexpr std::int32_t cooperative_split_k(Bf16GdnGatingScheduleId schedule) noexcept {
+    switch (schedule) {
+    case Bf16GdnGatingScheduleId::MmaCooperativeSplit32:
+        return 32;
+    case Bf16GdnGatingScheduleId::MmaCooperativeSplit16:
+        return 16;
+    case Bf16GdnGatingScheduleId::MmaCooperativeSplit8:
+        return 8;
+    case Bf16GdnGatingScheduleId::MmaCooperativeSplit4:
+        return 4;
+    case Bf16GdnGatingScheduleId::MmaCooperativeSplit2:
+        return 2;
+    default:
+        return 0;
+    }
+}
+
+// A cooperative launch requires the entire grid to be simultaneously resident. A route whose upper
+// bound exceeds the budget is not merely slow: the driver rejects the launch outright with
+// cudaErrorCooperativeLaunchTooLarge on the first prefill wide enough to reach it. Checking the
+// catalog at compile time turns that class of regression into a build failure.
+template <std::size_t N, typename Budget>
+constexpr bool catalog_is_resident(const std::array<RouteSpec, N>& routes, std::int32_t tile_cols,
+                                   std::int32_t row_tiles, Budget budget) noexcept {
+    for (const RouteSpec& route : routes) {
+        const std::int32_t split_k = cooperative_split_k(route.schedule);
+        if (split_k == 0) { continue; }
+        const std::int64_t column_tiles =
+            (static_cast<std::int64_t>(route.cols.last) + tile_cols - 1) / tile_cols;
+        if (column_tiles * row_tiles * split_k > budget(route.schedule)) { return false; }
+    }
+    return true;
+}
+
+static_assert(catalog_is_resident(k27Routes, 128, 3, resident_ctas_27),
+              "a 27B cooperative route exceeds the sm_86 resident-CTA budget at its upper bound");
+static_assert(catalog_is_resident(k35Routes, 64, 2, resident_ctas_35),
+              "a 35B cooperative route exceeds the sm_86 resident-CTA budget at its upper bound");
 
 bool is_27(const Bf16GdnGatingProblem& problem) noexcept {
     return problem.heads == 48 && problem.input_rows == 5120;
@@ -124,20 +180,21 @@ bool cooperative_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t
 }
 
 bool cooperative_27_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t cols) noexcept {
-    // BN128 uses 40 KiB of dynamic shared memory. Split8 uses 71 registers with 256 threads;
-    // split4/2 use 62 registers with 512 threads. Each specialization admits two CTAs/SM, hence
-    // 340 resident CTAs device-wide. There are three 16-row tiles per token tile.
-    return cooperative_grid_is_resident(schedule, cols, 128, 3, 340);
+    // sm_86, 82 SMs, 65,536 regs/SM, 100 KiB smem/SM. BN128 uses 40 KiB of dynamic shared memory,
+    // capping every specialization at two CTAs/SM by shared memory alone. Measured on the sm_86
+    // build (cuobjdump -res-usage): split8 uses 65 registers with 256 threads and reaches that
+    // 2 CTAs/SM -> 164 device-wide; split4/2 use 74 registers with 512 threads and are register
+    // bound to 1 CTA/SM -> 82. There are three 16-row tiles per token tile.
+    return cooperative_grid_is_resident(schedule, cols, 128, 3, resident_ctas_27(schedule));
 }
 
 bool cooperative_35_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t cols) noexcept {
-    // BN64 uses 24 KiB of dynamic shared memory and two 16-row tiles. With the registered CUDA
-    // 13.1/sm_120a build, split32 uses 91/93 registers per thread and admits two CTAs/SM;
-    // split16/8/4/2 use at most 62 registers and admit four CTAs/SM. Across 170 SMs the
-    // device-wide limits are 340 and 680 CTAs respectively.
-    const std::int32_t resident_ctas =
-        schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit32 ? 340 : 680;
-    return cooperative_grid_is_resident(schedule, cols, 64, 2, resident_ctas);
+    // BN64 uses 24 KiB of dynamic shared memory and two 16-row tiles, so shared memory alone
+    // admits four CTAs/SM. Measured on the sm_86 build (cuobjdump -res-usage): split32 uses
+    // 122-126 registers with 256 threads and is register bound to 2 CTAs/SM -> 164 device-wide
+    // across 82 SMs; split16 uses 56 registers and reaches the shared-memory bound of
+    // 4 CTAs/SM -> 328; split8/4/2 use 74 registers and are register bound to 3 CTAs/SM -> 246.
+    return cooperative_grid_is_resident(schedule, cols, 64, 2, resident_ctas_35(schedule));
 }
 
 bool candidate_is_legal(Bf16GdnGatingScheduleId schedule,

--- a/tests/ops/test_gdn_gating_proj.cpp
+++ b/tests/ops/test_gdn_gating_proj.cpp
@@ -435,11 +435,12 @@ int main() {
     }
 
     int failures = 0;
-    failures += verify_workspace_capacity_contract(kQwen27, {1, 8, 1024, 2048, 4096, 4097});
-    failures += verify_workspace_capacity_contract(kQwen35, {1, 127, 1024, 2048, 4096, 4097});
+    failures += verify_workspace_capacity_contract(kQwen27, {1, 8, 768, 1664, 1665});
+    failures += verify_workspace_capacity_contract(kQwen35, {1, 127, 960, 1920, 3904, 3905});
 
-    // Every registered 27B projection route, including predicated and full token tiles.
-    for (const std::int32_t tokens : {1, 8, 9, 1024, 1025, 2049, 4097}) {
+    // Every registered 27B projection route, including predicated and full token tiles, and both
+    // sides of each sm_86 residency boundary.
+    for (const std::int32_t tokens : {1, 8, 9, 768, 769, 1024, 1664, 1665, 2049, 4097}) {
         failures +=
             run_projection_case(kQwen27, tokens, 0x1000u + static_cast<std::uint32_t>(tokens));
     }


### PR DESCRIPTION
I hit a hard crash running Qwen3.8-27B on a 3090 with anything other than a short prompt, and it turned out to be the GDN gating projection using RTX 5090 residency constants. Filing the fix here since it is a 3090 specific thing.

## Reproducing it

Any prompt over roughly 768 tokens, with the shipped `--prefill-chunk 1024`:

```
ninfer.exe models\qwen3_8_27b.ninfer --messages long_prompt.json ^
  --max-context 16384 --kv-capacity 16384 --kv-dtype int8 ^
  --prefill-chunk 1024 --spec mtp --draft-tokens 3 --lm-head-draft
```

```
bf16_gdn_gating_proj_kernels.cu: CUDA_CHECK(cudaLaunchKernelEx(...)) failed:
cudaErrorCooperativeLaunchTooLarge: too many blocks in cooperative launch
```

I think this survived into a release because every published 3090 benchmark uses 29 to 34 token prompts. At that size the grid is one column tile and comfortably legal, so the boundary never gets touched.

## What is going on

The split-K schedules launch cooperatively, so the entire grid has to be resident at once. `cooperative_27_grid_is_resident` checks against 340 CTAs, which is 170 SMs times 2, so a 5090. A 3090 has 82 SMs. The planner admits grids about twice what the card can hold and the driver refuses them.

## Measuring instead of rescaling

I did not just swap 170 for 82, because the compiler does not allocate registers the same way on both targets. Reading `cuobjdump -res-usage` on the actual sm_86 objects:

| Schedule | Threads | Regs on sm_86 | Regs in the comment (sm_120a) | CTAs/SM | Device wide |
|---|---|---|---|---|---|
| 27B split8 | 256 | 65 | 71 | 2 | 164 |
| 27B split4/2 | 512 | 74 | 62 | 1 | 82 |
| 35B split32 | 256 | 122 to 126 | 91/93 | 2 | 164 |
| 35B split16 | 256 | 56 | at most 62 | 4 | 328 |
| 35B split8/4/2 | 256 | 74 | at most 62 | 3 | 246 |

Device limits confirmed from the CUDA API on the card: 82 SMs, 65536 regs/SM, 102400 bytes smem/SM, 1536 threads/SM.

The split4 and split2 case is the one that matters. The file says 62 registers, sm_86 gives 74, and that is the difference between 2 CTAs/SM and 1.

## The change

27B routes become 9 to 768 split8, 769 to 1664 split2, 1665 and up unsplit. Split4 hits the same 768 ceiling as split8 while doing less work per launch, so it falls out of the table entirely on this target.

35B route bounds clamp to 127, 960, 1920 and 3904. The current bounds of 1024, 2048 and 4096 each land on exactly 256 CTAs against a 246 limit, so all three are illegal here.

The budgets are now shared between the runtime predicate and a new compile time `catalog_is_resident` static_assert, so a retuned constant cannot quietly disagree with the route table it is supposed to bound. I checked the guard actually fires by putting the old bound back on a scratch copy and confirming the build fails with the intended message, since a guard that cannot fail is not worth much.

## Validation

Same CUDA 13.3 source build on native Windows and on WSL2, RTX 3090:

- `--prefill-chunk 1024` works where it used to crash
- greedy output at chunk 1024 is byte identical to chunk 768
- chunks 768, 896, 1152, 1664, 1792 and 2048 all land on legal schedules
- no throughput change, prefill stays flat between 678 and 706 tok/s across all of them

On unmodified code `ninfer_gdn_gating_proj_test` aborts with exit 134 on a 3090. With this change it reaches exit 1 and the 35B geometry passes completely.

## One thing I did not fix

Two numerical cases still fail, and I would rather flag them than bury them.

Above T=1664 there is no legal cooperative split-K schedule on 82 SMs, so MmaUnsplit is the only option left. Its single sequential FP32 accumulation over K=5120 is slightly less accurate than split-K's two level reduction, and T=1665 and T=2049 miss the 1.4e-6 relative_l2 projection criterion by about 4e-6. T=1664 on split2 passes, one token apart, which is a fairly clean demonstration that it is the schedule and not the size.

This looks like a real hardware limit rather than something the fix introduced. On a 5090 split-K stays legal to 4096 so it never comes up. Practical impact is nil since prefill throughput plateaus by chunk 384 and peaks at 640, but if you would prefer it to be unreachable rather than merely unreached, clamping `--prefill-chunk` to 1664 on sm_86 would do that at no cost. Happy to add that if you want it in this PR.

## Other things I found

Not in this PR, but I measured a few things while chasing this down and can send them separately if useful:

- prefill and TTFT curves from 8K to 128K, and where the useful context ceiling actually sits on 24GB once desktop VRAM is accounted for
- prefill is serialised across requests, so C4 and C8 stop helping once prompts get long, and requests can hit the 30s admission timeout and surface as 503s
- the published release binary allocates about 835 MiB of CUDA graph memory on the non `--spec` path and refuses to start, where a CUDA 13.3 source build of the same code uses 8 MiB
- `--prefill-chunk 640` measured slightly faster than 768 on both platforms