### PR TITLE
perf(gdn): run sm_86 split4/split2 at 8 warps to double the cooperative budget

### DIFF
--- a/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_kernels.cu
+++ b/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_kernels.cu
@@ -395,9 +395,12 @@ void bf16_gdn_gating_proj_mma_split4_launch(Bf16GdnGatingTokenVariant variant, c
                                             const Tensor& A_log, const Tensor& dt_bias,
                                             void* workspace, Tensor& g, Tensor& beta,
                                             cudaStream_t stream) {
-    launch_bf16_prefill_mma<Bf16Gdn27Geometry, 4>(variant, x, nullptr, 0.0F, nullptr, a_weight,
-                                                  b_weight, A_log, dt_bias, workspace, g, beta,
-                                                  stream);
+    // Eight warps, matching every other MMA route in this file. At 16 warps the CTA needs 512
+    // threads' worth of registers, which admits a single CTA per sm_86 SM and collapses the
+    // cooperative budget to 82. See the residency note in the plan's route table.
+    launch_bf16_prefill_mma<Bf16Gdn27Geometry, 4, 8>(variant, x, nullptr, 0.0F, nullptr, a_weight,
+                                                     b_weight, A_log, dt_bias, workspace, g, beta,
+                                                     stream);
 }
 
 void bf16_gdn_gating_proj_mma_split2_launch(Bf16GdnGatingTokenVariant variant, const Tensor& x,
@@ -405,9 +408,9 @@ void bf16_gdn_gating_proj_mma_split2_launch(Bf16GdnGatingTokenVariant variant, c
                                             const Tensor& A_log, const Tensor& dt_bias,
                                             void* workspace, Tensor& g, Tensor& beta,
                                             cudaStream_t stream) {
-    launch_bf16_prefill_mma<Bf16Gdn27Geometry, 2>(variant, x, nullptr, 0.0F, nullptr, a_weight,
-                                                  b_weight, A_log, dt_bias, workspace, g, beta,
-                                                  stream);
+    launch_bf16_prefill_mma<Bf16Gdn27Geometry, 2, 8>(variant, x, nullptr, 0.0F, nullptr, a_weight,
+                                                     b_weight, A_log, dt_bias, workspace, g, beta,
+                                                     stream);
 }
 
 void bf16_gdn_gating_proj_mma_unsplit_launch(Bf16GdnGatingTokenVariant variant, const Tensor& x,

--- a/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
+++ b/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
@@ -26,16 +26,17 @@ struct RouteSpec {
     Bf16GdnGatingScheduleId schedule;
 };
 
-constexpr std::array<RouteSpec, 5> k27Routes{{
+constexpr std::array<RouteSpec, 6> k27Routes{{
     {{1, 1}, Bf16GdnGatingScheduleId::GemvPairedRows},
     {{2, 8}, Bf16GdnGatingScheduleId::SmallTSplit10},
-    // sm_86 has 82 SMs. Split8 (256 threads, 65 regs) admits 2 CTAs/SM -> 164 device-wide;
-    // split4/2 (512 threads, 74 regs) admit 1 CTA/SM -> 82. Grid is ceil(T/128)*3*SplitK, so
-    // split8 is legal to T<=768 and split2 to T<=1664. Split4 reaches the same 768 ceiling as
-    // split8 while doing less work per launch, so it is unreachable on this target.
+    // sm_86 has 82 SMs, 64 Ki registers and 100 KiB of shared memory per SM. Every MMA route runs
+    // 8 warps at 65 registers, so 8*32*72 = 18,432 registers admits three CTAs/SM while the 40 KiB
+    // of dynamic shared memory admits two. Shared memory binds: 2 CTAs/SM -> 164 device-wide.
+    // Grid is ceil(T/128)*3*SplitK, so the legal ends are 768 / 1664 / 3456.
     {{9, 768}, Bf16GdnGatingScheduleId::MmaCooperativeSplit8},
-    {{769, 1664}, Bf16GdnGatingScheduleId::MmaCooperativeSplit2},
-    {{1665, kAnyCols}, Bf16GdnGatingScheduleId::MmaUnsplit},
+    {{769, 1664}, Bf16GdnGatingScheduleId::MmaCooperativeSplit4},
+    {{1665, 3456}, Bf16GdnGatingScheduleId::MmaCooperativeSplit2},
+    {{3457, kAnyCols}, Bf16GdnGatingScheduleId::MmaUnsplit},
 }};
 
 constexpr std::array<RouteSpec, 5> k35Routes{{
@@ -66,8 +67,10 @@ static_assert(catalog_is_closed(k35Routes, kAnyCols));
 // Device-wide resident-CTA budgets, measured on the sm_86 build. These are the single source of
 // truth: both the runtime residency predicates and the compile-time catalog guard below read them,
 // so a retuned constant cannot silently disagree with the route table it is meant to bound.
-constexpr std::int32_t resident_ctas_27(Bf16GdnGatingScheduleId schedule) noexcept {
-    return schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit8 ? 164 : 82;
+constexpr std::int32_t resident_ctas_27(Bf16GdnGatingScheduleId) noexcept {
+    // Uniform across split8/4/2: all three are 8-warp, 65-register CTAs bounded by the same 40 KiB
+    // shared-memory allocation, so all three admit two CTAs per SM.
+    return 164;
 }
 
 constexpr std::int32_t resident_ctas_35(Bf16GdnGatingScheduleId schedule) noexcept {

--- a/tests/ops/test_gdn_gating_proj.cpp
+++ b/tests/ops/test_gdn_gating_proj.cpp
@@ -435,12 +435,14 @@ int main() {
     }
 
     int failures = 0;
-    failures += verify_workspace_capacity_contract(kQwen27, {1, 8, 768, 1664, 1665});
+    failures +=
+        verify_workspace_capacity_contract(kQwen27, {1, 8, 768, 769, 1664, 1665, 3456, 3457});
     failures += verify_workspace_capacity_contract(kQwen35, {1, 127, 960, 1920, 3904, 3905});
 
     // Every registered 27B projection route, including predicated and full token tiles, and both
-    // sides of each sm_86 residency boundary.
-    for (const std::int32_t tokens : {1, 8, 9, 768, 769, 1024, 1664, 1665, 2049, 4097}) {
+    // sides of each sm_86 residency boundary (768/769, 1664/1665, 3456/3457).
+    for (const std::int32_t tokens :
+         {1, 8, 9, 768, 769, 1024, 1664, 1665, 2049, 3456, 3457, 4097}) {
         failures +=
             run_projection_case(kQwen27, tokens, 0x1000u + static_cast<std::uint32_t>(tokens));
     }


### PR DESCRIPTION
Follow-up to #2. That PR treated `split4/split2 = 82` as an sm_86 hardware limit. It isn't one, and fixing it removes the constraint.

## The change

`launch_bf16_prefill_mma` takes a `Warps` parameter defaulting to `kBf16GdnWarps = 16`. Eleven MMA launch sites pass `Warps = 8` explicitly. The only two that don't are the 27B split4 and split2, which are exactly the two schedules stuck at 82. Both widths are already supported (`static_assert(Warps == 8 || Warps == 16)`).

At 512 threads the register file admits 1 CTA/SM. At 256 threads shared memory binds at 2. Registers also drop 74 to 65, `STACK:0 LOCAL:0`, nothing spills.

| | 8 warps | 16 warps |
|---|---:|---:|
| Registers/CTA | 18,432 | 40,960 |
| CTAs/SM by registers | 3 | **1** |
| CTAs/SM by shared memory (40 KiB) | 2 | 2 |
| **Device-wide (x82 SMs)** | **164** | **82** |

Since shared memory is what binds at 8 warps, any register count up to 128/thread still gives 164, so this isn't sensitive to compiler drift.

## Result

Routes follow from `grid = ceil(T/128) * 3 * SplitK <= 164`, so 768 / 1664 / 3456. Split4 stops being unreachable and `MmaUnsplit` moves from T >= 1665 out to T >= 3457.

The two correctness cases #2 left failing now pass. Ratios are `observed / limit` against `kGdnProjectionFp32`, same seeds:

| T | before | after |
|---:|---|---|
| 769 | Split2, 0.447 | Split4, **0.207** |
| 1024 | Split2, 0.563 | Split4, **0.281** |
| 1664 | Split2, 0.383 | Split4, **0.175** |
| 1665 | Unsplit, **1.017 FAIL** | Split2, **0.453 pass** |
| 2049 | Unsplit, **1.033 FAIL** | Split2, **0.427 pass** |

**This is not a speedup.** I measured it as a same-session A/B at chunks 640 to 3456 and every delta was inside run-to-run spread. Nsight Systems says why: the gating projection is 0.1% of prefill GPU time. This buys correctness and headroom, not throughput.

**It answers the clamp question raised on #2.** The suggestion there was to clamp shipped launchers to `<= 1664` to keep `MmaUnsplit` out of play. That boundary is now 3456, so no clamp is needed below it, and `--prefill-chunk 1024` routes to Split4.

**The 35B is untouched.** All six of its routes already passed `Warps = 8`. I did not alter `k35Routes` or `resident_ctas_35`, and every 35B case still passes.

**One case still fails and it is not sm_86 specific.** T=3457 fails at 1.212 on `MmaUnsplit`. That path does not meet the 1.4e-6 `relative_l2` bound at K=5120 on any architecture: the route table sends T >= 4097 to `MmaUnsplit` everywhere, and T=4097 is the only sample the test has, passing at 0.996. The 35B's `MmaUnsplit` measures 0.208 because its K is 2048. Happy to follow up with a route-scoped criterion or a non-cooperative split-K path.

## Tested with

Base `1d189728`. Release build, Ninja, `-DCMAKE_CUDA_ARCHITECTURES=86`.

| | |
|---|---|
| GPU | RTX 3090 24 GB, sm_86, driver 610.88 |
| CUDA | 13.3.73 |
| OS | Ubuntu 24.04.4 LTS on WSL2 2.6.1.0, kernel 6.6.87.2 |
| Host | Windows 11 build 26200 |
| Model | `qwen3_8_27b.ninfer`, sha256 `eec39564…514bf3e` |

- `ninfer_gdn_gating_proj_test`: all 27B and 35B cases pass except the T=3457 case above. The compile-time `catalog_is_resident` guard accepts the new bounds and the driver accepted every cooperative launch, including Split2 at its 162-CTA upper bound.
- Full `ctest`: no new failures. The other failures on this hardware are pre-existing and all one cause, `NVFP4 A4 execution requires an sm_120a GPU` thrown uncaught so the process aborts instead of skipping.
- Occupancy re-measured after the change with `cuobjdump -res-usage`. The model reproduces all nine kernel variants, including the 35B's 246, which the driver independently reported as `exceed occupancy limit for this kernel on this device of 246 blocks`.
- `git diff --check` clean, lines within the 100-column limit.

These bounds are sm_86-derived, same as #2.

## Ask: please re-cut the Windows binary

The published `ninfer-rtx3090-windows-x64-0.6.0-rtx3090.zip` was built from tag `2ae51915` and does not contain #2, let alone this PR. Anyone downloading v0.6.0 still hits the crash #2 fixes.

Confirmed against the shipped binary rather than inferred. Decoding the `RouteSpec` table out of `.rdata` in the released `ninfer-serve.exe` (sha256 `b5273281…5b9e590f`) gives the pre-fix six-entry catalog at offset `0x410190`, with `{9, 1024} -> MmaCooperativeSplit8`, which is 192 CTAs against a 164 budget. Scanning for the corrected bounds `{9,768}` and `{769,1664}` returns zero hits.

The bundled `run-qwen38-c1.bat` and `run-qwen38-c8.bat` both pass `--prefill-chunk 1024`, so running either as shipped and sending a prompt over 768 tokens crashes. An agent client reaches that on its first request, since tool schemas alone clear the threshold. The two vision launchers use 512 and are fine.

Re-cutting from branch head would ship #2 and, if this merges, remove the `<= 1664` concern as well. Credit to @OmbraRD, who reported the release gap on #2; I verified it independently on my own 3090.
