### PR TITLE
fix(runtime): stop aborting startup on a device-wide memory reading

### DIFF
--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -1334,13 +1334,24 @@ void ProgramImplCore::prepare_graphs() {
 
     std::size_t free_after = 0;
     CUDA_CHECK(cudaMemGetInfo(&free_after, &total_bytes));
+    // cudaMemGetInfo reports free memory for the whole device, so this delta measures every other
+    // GPU consumer's allocations and frees during capture as well as our own. On any machine with a
+    // display attached that is not a small correction. Measured on an RTX 3090 with a Windows
+    // desktop present, twelve identical runs at a 2048-token capacity: 0, 0, 0, 8.00, 9.44, 9.89,
+    // 14.77, 21.11, 21.75, 26.44, 84.50, 101.00 MiB. The zeroes are the clamp below firing because
+    // another process freed more than we allocated. Ten identical runs at 131072 spanned 0 to
+    // 277.25 MiB; variance grows as the KV cache squeezes the desktop, which is why the failures
+    // looked capacity-dependent.
+    //
+    // Aborting startup on that reading rejected more than half of otherwise valid configurations.
+    // The number cannot be isolated either: these graphs contain no memory nodes, every buffer
+    // comes from the planned arena, so cudaDeviceGetGraphMemAttribute reads zero and what remains
+    // is opaque cudaGraphInstantiate bookkeeping. It is kept as a reported diagnostic instead of a
+    // precondition. graph_allowance_bytes still reserves its share of device_reservation_bytes, so
+    // planning is unchanged, and a genuine over-allocation now surfaces as a real CUDA OOM naming
+    // the allocation that failed rather than as a spurious startup error naming this one.
     const std::size_t consumed = free_before > free_after ? free_before - free_after : 0;
     graph_observed_bytes       = consumed;
-    if (consumed > graph_allowance_bytes) {
-        throw std::runtime_error("CUDA Graph preparation consumed " + std::to_string(consumed) +
-                                 " bytes, exceeding the planned allowance of " +
-                                 std::to_string(graph_allowance_bytes) + " bytes");
-    }
     for (PagedKVAllocation& allocation : dflash_capture_allocations) { allocation.unbind_row(); }
     dflash_capture_allocations.clear();
     for (PagedKVAllocation& allocation : mtp_capture_allocations) { allocation.unbind_row(); }

--- a/tools/bench/run_graph_allowance_sweep.py
+++ b/tools/bench/run_graph_allowance_sweep.py
@@ -1,0 +1,211 @@
+"""Measure CUDA Graph memory consumption against KV capacity.
+
+The engine plans a graph allowance at startup and aborts if capture exceeds it::
+
+    error: CUDA Graph preparation consumed 875819008 bytes, exceeding the planned
+    allowance of 12582912 bytes
+
+The non-speculative allowance is a flat ``12 MiB * max_concurrency`` with no capacity term
+(``layouts_impl.h``), while the number of captured graphs is
+``len(ordinary_graph_profiles(capacity)) * max_concurrency`` (``variant.cpp``). This sweep measures
+what capture actually costs so the allowance can be given a defensible formula instead of a
+constant.
+
+No profiler is involved. The CLI prints ``CUDA Graph memory <observed> / <allowance>`` itself, and
+a failure names both figures in the error text, so a failed run is still a data point.
+
+Two properties of the measurement drive the design:
+
+**It is a device-wide delta, not this process's allocation.** ``prepare_graphs`` brackets capture
+with two ``cudaMemGetInfo`` calls, so anything else resident on the GPU during that window lands in
+the number. Repeats are therefore mandatory: a single reading per capacity cannot distinguish a
+real curve from desktop VRAM drift. ``--repeats`` defaults to 3 and the report leads with spread.
+
+**Capture is eager and happens at construction**, before any prompt is seen. Prompt length cannot
+affect it. The prompt here is deliberately trivial and ``--max-new`` is 1: this measures startup,
+so each point costs roughly one model load rather than a benchmark run.
+
+Usage::
+
+    export LD_LIBRARY_PATH=/usr/lib/wsl/drivers/nvddi.inf_amd64_dabe455c4b5cf6f0:/usr/lib/wsl/lib
+    python3 -m tools.bench.run_graph_allowance_sweep --repeats 3
+    python3 -m tools.bench.run_graph_allowance_sweep --spec mtp --draft-tokens 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import subprocess
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CLI = ROOT / "build/apps/ninfer"
+DEFAULT_MODEL = Path.home() / "ai/models/qwen3_8_27b.ninfer"
+
+MIB = 1024 * 1024
+
+# Mirrors Variant::ordinary_graph_profiles in src/targets/qwen3_6_27b/impl/variant.cpp. Kept here so
+# the report can state the predicted graph count next to the measured cost; if the source table
+# changes this must change with it, which is why the values are quoted rather than derived.
+ORDINARY_PROFILE_ENDS = (127, 511, 2047, 4095, 8197, 16389, 32767)
+
+# Capacities either side of every profile boundary, plus the four points already measured by hand.
+# Boundaries are where the graph count steps, so they are where a count-driven model and a
+# frontier-driven model disagree most.
+DEFAULT_CAPACITIES = (
+    2048, 4096, 8198, 16390,
+    32768, 32832, 40960, 49152, 65536, 81920, 103424, 131072,
+)
+
+SUMMARY = re.compile(r"^\s*([a-zA-Z][a-zA-Z0-9 _/-]*?)\s{2,}(.+?)\s*$")
+# A bare "B" unit is not a formatting curiosity: the engine clamps a negative device-wide delta to
+# zero, so "0 B" is the signature of another process freeing VRAM during capture. It must parse.
+GRAPH_LINE = re.compile(r"CUDA Graph memory\s+([\d.]+)\s*([KMG]?i?B)\s*/\s*([\d.]+)\s*([KMG]?i?B)")
+GRAPH_ERROR = re.compile(
+    r"CUDA Graph preparation consumed (\d+) bytes, exceeding the planned allowance of (\d+) bytes"
+)
+UNITS = {"B": 1, "KiB": 1024, "MiB": MIB, "GiB": 1024 * MIB}
+
+
+def ordinary_graph_count(capacity: int, concurrency: int = 1) -> int:
+    """Number of ordinary decode graphs captured for a capacity.
+
+    Mirrors graph_profiles_through(capacity - 1, ORDINARY_PROFILE_ENDS) exactly, including its
+    early return when a range lands on the frontier.
+    """
+    max_frontier = capacity - 1
+    profiles = 0
+    begin = 0
+    for preferred_end in ORDINARY_PROFILE_ENDS:
+        if begin > max_frontier:
+            break
+        end = min(preferred_end, max_frontier)
+        profiles += 1
+        if end == max_frontier:
+            return profiles * concurrency
+        begin = end + 1
+    if begin <= max_frontier:
+        profiles += 1
+    return profiles * concurrency
+
+
+def parse_bytes(value: str, unit: str) -> int:
+    return int(round(float(value) * UNITS[unit]))
+
+
+def measure(cli: Path, model: Path, capacity: int, spec: str | None, draft_tokens: int,
+            kv_dtype: str, prefill_chunk: int) -> dict:
+    command = [
+        str(cli), str(model),
+        "--prompt", "hi",
+        "--max-context", str(capacity),
+        "--kv-capacity", str(capacity),
+        "--kv-dtype", kv_dtype,
+        "--prefill-chunk", str(prefill_chunk),
+        "--max-new", "1",
+        "--greedy", "--no-thinking",
+    ]
+    if spec:
+        command += ["--spec", spec, "--draft-tokens", str(draft_tokens), "--lm-head-draft"]
+
+    started = time.perf_counter()
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    wall = time.perf_counter() - started
+
+    observed = allowance = None
+    # A run that aborts still reports both figures, in exact bytes rather than the summary's
+    # two-decimal MiB, so failures are the more precise data points.
+    error = GRAPH_ERROR.search(result.stderr)
+    if error:
+        observed, allowance = int(error.group(1)), int(error.group(2))
+    else:
+        line = GRAPH_LINE.search(result.stderr)
+        if line:
+            observed = parse_bytes(line.group(1), line.group(2))
+            allowance = parse_bytes(line.group(3), line.group(4))
+
+    return {
+        "capacity": capacity,
+        "returncode": result.returncode,
+        "started": result.returncode == 0,
+        "graph_blocked": error is not None,
+        "observed_bytes": observed,
+        "allowance_bytes": allowance,
+        "predicted_graphs": ordinary_graph_count(capacity),
+        "wall_s": round(wall, 2),
+        "stderr_tail": result.stderr.strip().splitlines()[-1] if result.returncode else "",
+        # A run that neither reports a figure nor aborts is the one case this sweep cannot
+        # interpret, so keep its output rather than recording a silent None.
+        "unparsed_stderr": None if observed is not None else result.stderr[-4000:],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--cli", type=Path, default=DEFAULT_CLI)
+    parser.add_argument("--model", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument("--capacities", type=int, nargs="*", default=list(DEFAULT_CAPACITIES))
+    parser.add_argument("--repeats", type=int, default=3,
+                        help="runs per capacity; >1 is required to separate curve from noise")
+    parser.add_argument("--spec", choices=["mtp"], default=None)
+    parser.add_argument("--draft-tokens", type=int, default=3)
+    parser.add_argument("--kv-dtype", default="int8")
+    parser.add_argument("--prefill-chunk", type=int, default=640)
+    parser.add_argument("--out", type=Path, default=ROOT / "out/graph_allowance")
+    args = parser.parse_args()
+
+    if not args.cli.exists():
+        raise SystemExit(f"engine binary not found: {args.cli}")
+    if not args.model.exists():
+        raise SystemExit(f"model artifact not found: {args.model}")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+
+    print(f"{'capacity':>9}  {'graphs':>6}  {'observed':>12}  {'allowance':>10}  {'per graph':>10}  "
+          f"{'spread':>8}  result")
+    for capacity in args.capacities:
+        runs = [
+            measure(args.cli, args.model, capacity, args.spec, args.draft_tokens,
+                    args.kv_dtype, args.prefill_chunk)
+            for _ in range(args.repeats)
+        ]
+        rows.extend(runs)
+
+        seen = [r["observed_bytes"] for r in runs if r["observed_bytes"] is not None]
+        graphs = runs[0]["predicted_graphs"]
+        if not seen:
+            print(f"{capacity:>9}  {graphs:>6}  {'—':>12}  {'—':>10}  {'—':>10}  {'—':>8}  "
+                  f"no graph figure reported")
+            continue
+
+        median = statistics.median(seen)
+        spread = max(seen) - min(seen)
+        allowance = next(r["allowance_bytes"] for r in runs if r["allowance_bytes"] is not None)
+        blocked = sum(1 for r in runs if r["graph_blocked"])
+        verdict = "ok" if blocked == 0 else f"BLOCKED {blocked}/{len(runs)}"
+        print(f"{capacity:>9}  {graphs:>6}  {median / MIB:>10.2f} MiB  {allowance / MIB:>8.2f} MiB  "
+              f"{median / graphs / MIB:>8.2f} MiB  {spread / MIB:>6.2f} MiB  {verdict}")
+
+    report = {
+        "config": {
+            "cli": str(args.cli), "model": str(args.model), "repeats": args.repeats,
+            "spec": args.spec, "draft_tokens": args.draft_tokens if args.spec else None,
+            "kv_dtype": args.kv_dtype, "prefill_chunk": args.prefill_chunk,
+        },
+        "runs": rows,
+    }
+    label = args.spec or "ordinary"
+    destination = args.out / f"graph-allowance-{label}-{args.kv_dtype}.json"
+    destination.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"\nwrote {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

`prepare_graphs()` measures its own memory cost as the difference between two `cudaMemGetInfo` calls and aborts startup if the delta exceeds the planned graph allowance. But `cudaMemGetInfo` reports free memory for the **whole device**, so the delta includes every other GPU consumer's allocations and frees during the capture window. On any machine where the card also drives a display, the contamination dwarfs the signal and valid configurations are rejected at startup:

```
error: CUDA Graph preparation consumed 875819008 bytes, exceeding the planned allowance of 12582912 bytes
```

## Evidence (RTX 3090, CUDA 13.3, sm_86, Windows desktop present)

Twelve consecutive runs, identical flags, `--kv-capacity 2048` (3 captured graphs), reading in MiB:

```
0.00  0.00  0.00  8.00  9.44  9.89  14.77  21.11  21.75  26.44  84.50  101.00
```

Six of twelve exceeded the 12 MiB allowance and aborted. Ten runs at `--kv-capacity 131072` spanned 0 to 277 MiB and aborted six times. The exact-zero readings are the clamp firing because *another process freed more than we allocated* — only possible with a device-wide delta, which is the smoking gun.

Capacity is not the variable: 2048 fails as readily as 131072. What grows with capacity is the **variance** (a larger KV cache squeezes the desktop), which is why one-run-per-capacity sweeps produce a convincing but spurious upward curve.

## Why the number can't be fixed instead

These graphs contain no memory nodes — every buffer comes from the planned arena — so `cudaDeviceGetGraphMemAttribute` reads zero, and the residue is opaque `cudaGraphInstantiate` bookkeeping that CUDA does not expose per-process. There is no per-process figure to gate on; any check built on `cudaMemGetInfo` deltas is gating on other tenants' memory traffic, on every OS. (A recurring ~8 MiB reading, flat across a 24× capacity range on a quiet card, is the best estimate of the true cost — it fits inside the existing allowance. The budget was never the problem.)

## Fix

Drop the abort; keep the measurement as the reported diagnostic (both frontends already print `CUDA Graph memory <observed> / <allowance>`). `graph_allowance_bytes` still reserves its share of `device_reservation_bytes`, so planning is unchanged. A genuine over-allocation now surfaces as a real CUDA OOM naming the allocation that failed, rather than a spurious startup error naming this one. No test asserted the abort.

Also adds `tools/bench/run_graph_allowance_sweep.py`, which reproduces all of the above without a profiler (repeats-first design, since a single reading per capacity cannot distinguish a real curve from desktop VRAM drift).

## Verification

- `--kv-capacity 2048`: 6/12 runs blocked before → 10/10 start after
- `--kv-capacity 131072`: 6/10 blocked before → 10/10 start after
- 64,497-token prompt at `--kv-capacity 103424` with graphs on: 671.6 / 664.2 tok/s prefill, retrieval probe answered correctly

Coverage note: measured on a 3090 under WSL with a Windows desktop on the card. Headed bare-metal Linux shares the same mechanism (device-wide delta + display compositor traffic) but was not separately measured; headless behavior is unchanged in the common case since the true cost fits the allowance.
