### PR TITLE
Linux/GeForce fixes: CUDA compat libs, runtime SM count, ECC warning (+ first 3090 Ti numbers)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,16 @@ RUN apt-get update \
         libswscale7 \
     && rm -rf /var/lib/apt/lists/*
 
+# The CUDA runtime image ships forward-compatibility libraries in
+# /usr/local/cuda*/compat (a newer libcuda.so than the host driver). Forward
+# compatibility is supported only on datacenter GPUs; on any GeForce card the
+# loader picks these up and every CUDA call fails at startup with
+#   cudaErrorCompatNotSupportedOnDevice: forward compatibility was attempted
+#   on non supported HW
+# Removing them lets the container use the host driver through ordinary CUDA
+# minor-version compatibility, which is what an RTX 3090/3090 Ti needs.
+RUN rm -rf /usr/local/cuda-13.1/compat /usr/local/cuda-13/compat /usr/local/cuda/compat
+
 COPY --from=build /build/apps/ninfer /usr/local/bin/ninfer
 COPY --from=build /build/apps/ninfer-serve /usr/local/bin/ninfer-serve
 

--- a/Dockerfile.nocompat
+++ b/Dockerfile.nocompat
@@ -1,5 +1,0 @@
-FROM ninfer-3090:sm86-stock
-# CUDA forward-compatibility libs (libcuda.so.590) are datacenter-only and break
-# GeForce cards with cudaErrorCompatNotSupportedOnDevice. Remove them so the
-# container uses the host driver via normal CUDA minor-version compatibility.
-RUN rm -rf /usr/local/cuda-13.1/compat /usr/local/cuda-13/compat /usr/local/cuda/compat

--- a/Dockerfile.nocompat
+++ b/Dockerfile.nocompat
@@ -1,0 +1,5 @@
+FROM ninfer-3090:sm86-stock
+# CUDA forward-compatibility libs (libcuda.so.590) are datacenter-only and break
+# GeForce cards with cudaErrorCompatNotSupportedOnDevice. Remove them so the
+# container uses the host driver via normal CUDA minor-version compatibility.
+RUN rm -rf /usr/local/cuda-13.1/compat /usr/local/cuda-13/compat /usr/local/cuda/compat

--- a/src/core/device.cu
+++ b/src/core/device.cu
@@ -116,6 +116,8 @@ DeviceContext& DeviceContext::operator=(DeviceContext&& other) noexcept {
 
 int DeviceContext::sm() const noexcept { return props.major * 10 + props.minor; }
 
+int DeviceContext::sm_count() const noexcept { return props.multiProcessorCount; }
+
 std::size_t DeviceContext::total_vram() const noexcept { return props.totalGlobalMem; }
 
 void DeviceContext::synchronize() const { CUDA_CHECK(cudaStreamSynchronize(stream)); }

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -25,6 +25,10 @@ struct DeviceContext {
     DeviceContext& operator=(DeviceContext&& other) noexcept;
 
     int sm() const noexcept;
+    // Streaming-multiprocessor count of the attached device. Distinct from sm(), which returns
+    // the compute capability: every sm_86 part shares capability 86 but not this count (RTX 3090
+    // has 82, RTX 3090 Ti has 84), so any device-wide residency budget must read this, not sm().
+    int sm_count() const noexcept;
     std::size_t total_vram() const noexcept;
     void synchronize() const;
 };

--- a/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
+++ b/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
@@ -2,6 +2,8 @@
 
 #include "ninfer/ops/rmsnorm.h"
 
+#include <cuda_runtime_api.h>
+
 #include <algorithm>
 #include <array>
 #include <limits>
@@ -29,7 +31,7 @@ struct RouteSpec {
 constexpr std::array<RouteSpec, 6> k27Routes{{
     {{1, 1}, Bf16GdnGatingScheduleId::GemvPairedRows},
     {{2, 8}, Bf16GdnGatingScheduleId::SmallTSplit10},
-    // sm_86 has 82 SMs, 64 Ki registers and 100 KiB of shared memory per SM. Every MMA route runs
+    // sm_86 has 64 Ki registers and 100 KiB of shared memory per SM. Every MMA route runs
     // 8 warps at 65 registers, so 8*32*72 = 18,432 registers admits three CTAs/SM while the 40 KiB
     // of dynamic shared memory admits two. Shared memory binds: 2 CTAs/SM -> 164 device-wide.
     // Grid is ceil(T/128)*3*SplitK, so the legal ends are 768 / 1664 / 3456.
@@ -64,19 +66,57 @@ constexpr bool catalog_is_closed(const std::array<RouteSpec, N>& routes,
 static_assert(catalog_is_closed(k27Routes, kAnyCols));
 static_assert(catalog_is_closed(k35Routes, kAnyCols));
 
-// Device-wide resident-CTA budgets, measured on the sm_86 build. These are the single source of
-// truth: both the runtime residency predicates and the compile-time catalog guard below read them,
-// so a retuned constant cannot silently disagree with the route table it is meant to bound.
-constexpr std::int32_t resident_ctas_27(Bf16GdnGatingScheduleId) noexcept {
+// Per-SM resident-CTA occupancy, measured on the sm_86 build with cuobjdump -res-usage. These are
+// the single source of truth: both the runtime residency predicates and the compile-time catalog
+// guard below read them, so a retuned constant cannot silently disagree with the route table it is
+// meant to bound.
+//
+// Occupancy is a property of the compiled kernel (registers, shared memory, block size) and so is
+// fixed for a given sm_86 build. The device-wide budget is this figure times the SM count, which is
+// NOT fixed across sm_86: the RTX 3090 has 82 SMs and the RTX 3090 Ti has 84. Keep the two separate
+// -- multiply by the runtime SM count for the residency predicate, and by the minimum supported SM
+// count for the compile-time guard.
+constexpr std::int32_t ctas_per_sm_27(Bf16GdnGatingScheduleId) noexcept {
     // Uniform across split8/4/2: all three are 8-warp, 65-register CTAs bounded by the same 40 KiB
     // shared-memory allocation, so all three admit two CTAs per SM.
-    return 164;
+    return 2;
 }
 
-constexpr std::int32_t resident_ctas_35(Bf16GdnGatingScheduleId schedule) noexcept {
-    if (schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit32) { return 164; }
-    if (schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit16) { return 328; }
-    return 246;
+constexpr std::int32_t ctas_per_sm_35(Bf16GdnGatingScheduleId schedule) noexcept {
+    if (schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit32) { return 2; }
+    if (schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit16) { return 4; }
+    return 3;
+}
+
+// Fewest SMs of any device this build supports. The RTX 3090 is the smallest sm_86 part the fork
+// targets, so the compile-time catalog guard is checked against it: a route that fits on 82 SMs
+// fits on every supported device. Overshooting the real budget is not merely slow -- the driver
+// rejects the launch with cudaErrorCooperativeLaunchTooLarge -- so this must stay a lower bound.
+inline constexpr std::int32_t kMinSupportedSmCount = 82;
+
+// Cached SM count of the active device. cudaDeviceGetAttribute is cheap but this sits on the
+// per-request planning path, so read it once. Falling back to the documented minimum keeps the
+// predicate safe if the query ever fails.
+std::int32_t device_sm_count() noexcept {
+    static const std::int32_t count = [] {
+        int device = 0;
+        if (cudaGetDevice(&device) != cudaSuccess) { return kMinSupportedSmCount; }
+        int sms = 0;
+        if (cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device) != cudaSuccess ||
+            sms <= 0) {
+            return kMinSupportedSmCount;
+        }
+        return static_cast<std::int32_t>(sms);
+    }();
+    return count;
+}
+
+std::int32_t resident_ctas_27(Bf16GdnGatingScheduleId schedule) noexcept {
+    return ctas_per_sm_27(schedule) * device_sm_count();
+}
+
+std::int32_t resident_ctas_35(Bf16GdnGatingScheduleId schedule) noexcept {
+    return ctas_per_sm_35(schedule) * device_sm_count();
 }
 
 // Zero marks a schedule that is not launched cooperatively and therefore carries no residency
@@ -115,10 +155,18 @@ constexpr bool catalog_is_resident(const std::array<RouteSpec, N>& routes, std::
     return true;
 }
 
-static_assert(catalog_is_resident(k27Routes, 128, 3, resident_ctas_27),
-              "a 27B cooperative route exceeds the sm_86 resident-CTA budget at its upper bound");
-static_assert(catalog_is_resident(k35Routes, 64, 2, resident_ctas_35),
-              "a 35B cooperative route exceeds the sm_86 resident-CTA budget at its upper bound");
+static_assert(catalog_is_resident(k27Routes, 128, 3,
+                                  [](Bf16GdnGatingScheduleId schedule) constexpr noexcept {
+                                      return ctas_per_sm_27(schedule) * kMinSupportedSmCount;
+                                  }),
+              "a 27B cooperative route exceeds the sm_86 resident-CTA budget at its upper bound "
+              "on the smallest supported device");
+static_assert(catalog_is_resident(k35Routes, 64, 2,
+                                  [](Bf16GdnGatingScheduleId schedule) constexpr noexcept {
+                                      return ctas_per_sm_35(schedule) * kMinSupportedSmCount;
+                                  }),
+              "a 35B cooperative route exceeds the sm_86 resident-CTA budget at its upper bound "
+              "on the smallest supported device");
 
 bool is_27(const Bf16GdnGatingProblem& problem) noexcept {
     return problem.heads == 48 && problem.input_rows == 5120;
@@ -183,20 +231,21 @@ bool cooperative_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t
 }
 
 bool cooperative_27_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t cols) noexcept {
-    // sm_86, 82 SMs, 65,536 regs/SM, 100 KiB smem/SM. BN128 uses 40 KiB of dynamic shared memory,
-    // capping every specialization at two CTAs/SM by shared memory alone. Measured on the sm_86
-    // build (cuobjdump -res-usage): split8 uses 65 registers with 256 threads and reaches that
-    // 2 CTAs/SM -> 164 device-wide; split4/2 use 74 registers with 512 threads and are register
-    // bound to 1 CTA/SM -> 82. There are three 16-row tiles per token tile.
+    // sm_86, 65,536 regs/SM, 100 KiB smem/SM. BN128 uses 40 KiB of dynamic shared memory, capping
+    // every specialization at two CTAs/SM by shared memory alone. Measured on the sm_86 build
+    // (cuobjdump -res-usage): split8 uses 65 registers with 256 threads and reaches that 2 CTAs/SM.
+    // split4/2 were rebuilt at 8 warps and now reach the same 2 CTAs/SM; ctas_per_sm_27 is uniform
+    // for that reason. There are three 16-row tiles per token tile. The device-wide budget is this
+    // per-SM figure times the runtime SM count -- 82 on an RTX 3090, 84 on an RTX 3090 Ti.
     return cooperative_grid_is_resident(schedule, cols, 128, 3, resident_ctas_27(schedule));
 }
 
 bool cooperative_35_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t cols) noexcept {
     // BN64 uses 24 KiB of dynamic shared memory and two 16-row tiles, so shared memory alone
     // admits four CTAs/SM. Measured on the sm_86 build (cuobjdump -res-usage): split32 uses
-    // 122-126 registers with 256 threads and is register bound to 2 CTAs/SM -> 164 device-wide
-    // across 82 SMs; split16 uses 56 registers and reaches the shared-memory bound of
-    // 4 CTAs/SM -> 328; split8/4/2 use 74 registers and are register bound to 3 CTAs/SM -> 246.
+    // 122-126 registers with 256 threads and is register bound to 2 CTAs/SM; split16 uses 56
+    // registers and reaches the shared-memory bound of 4 CTAs/SM; split8/4/2 use 74 registers and
+    // are register bound to 3 CTAs/SM. Multiply by the runtime SM count for the device-wide budget.
     return cooperative_grid_is_resident(schedule, cols, 64, 2, resident_ctas_35(schedule));
 }
 

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -5,6 +5,8 @@
 #include "serve/tool_call_parser.h"
 #include "serve/translate.h"
 
+#include <cuda_runtime_api.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
@@ -249,6 +251,23 @@ private:
 
 GenerationService::GenerationService(ServeOptions options, LoadProgress load_progress)
     : options_(std::move(options)) {
+    // Inline ECC on GDDR6X GeForce cards reserves ~6.25% of VRAM for checksums and taxes
+    // memory bandwidth on every access. Decode is bandwidth-bound, so an ECC-enabled card
+    // silently loses a large share of its published throughput and KV capacity while looking
+    // exactly like an engine regression. ECC is off by default on GeForce; warn loudly when
+    // someone (or some tool) left it on.
+    {
+        cudaDeviceProp props{};
+        if (cudaGetDeviceProperties(&props, options_.device) == cudaSuccess &&
+            props.ECCEnabled != 0) {
+            write_console_log(ConsoleLogLevel::Warning,
+                              std::string("ECC is ENABLED on ") + props.name +
+                                  ": expect markedly lower decode throughput and ~6.25% less "
+                                  "usable VRAM than published RTX 3090/3090 Ti results. If this "
+                                  "is not a deliberate reliability choice, disable it with "
+                                  "`nvidia-smi -e 0` and reboot.");
+        }
+    }
     ninfer::EngineOptions engine_options;
     engine_options.artifact_path        = options_.artifact_path;
     engine_options.device               = options_.device;

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -262,10 +262,12 @@ GenerationService::GenerationService(ServeOptions options, LoadProgress load_pro
             props.ECCEnabled != 0) {
             write_console_log(ConsoleLogLevel::Warning,
                               std::string("ECC is ENABLED on ") + props.name +
-                                  ": expect markedly lower decode throughput and ~6.25% less "
-                                  "usable VRAM than published RTX 3090/3090 Ti results. If this "
-                                  "is not a deliberate reliability choice, disable it with "
-                                  "`nvidia-smi -e 0` and reboot.");
+                                  ": GDDR6X stores ECC checksums in VRAM, costing ~6.25% of "
+                                  "capacity (23,028 vs 24,564 MiB on a 24 GB card) and ~12% of "
+                                  "memory bandwidth (measured 803 vs 902 GB/s on an RTX 3090 Ti). "
+                                  "KV capacity and prefill suffer accordingly. ECC is off by "
+                                  "default on GeForce; if this is not a deliberate reliability "
+                                  "choice, disable it with `nvidia-smi -e 0` and reboot.");
         }
     }
     ninfer::EngineOptions engine_options;


### PR DESCRIPTION
Four changes from getting this fork running on Linux with an RTX 3090 Ti. I believe this is the first real-artifact Linux run — the README lists Linux generation and performance qualification as open, and the first commit here is what was blocking it.

Environment: RTX 3090 Ti (84 SMs, ECC off), driver 580.167.08 / CUDA 13.0, Ubuntu 22.04 host, Docker build (Ubuntu 24.04, CUDA 13.1, GCC 13), all 245 steps. Artifact `qwen3_8_27b.ninfer`, 16.96 GiB.

### 1. `fix(docker)` — CUDA forward-compat libs break every GeForce card

This one blocks all GeForce users of the Linux image. The CUDA 13.1 runtime base image ships `/usr/local/cuda*/compat` with a `libcuda.so.590`, the loader prefers it over the host driver, and forward compatibility is datacenter-only:

```
[error] ninfer-serve: cudaGetDeviceCount failed: cudaErrorCompatNotSupportedOnDevice:
forward compatibility was attempted on non supported HW
```

Removing those directories lets the container reach the host driver through ordinary minor-version compatibility. With this, CUDA 13.1 binaries run fine on a CUDA 13.0 driver.

### 2. `fix(gdn)` — `sm_86` is a compute capability, not an SM count

`bf16_gdn_gating_proj_plan.cpp` hardcodes device-wide cooperative-launch budgets (164/246/328) measured on an RTX 3090's 82 SMs, but `docs/rtx-3090-linux.md` documents RTX 3090 Ti support and that card has 84. Easy to miss, partly because `DeviceContext::sm()` returns 86 and there was no accessor for the actual count.

The change separates the two: `ctas_per_sm_*` keeps the measured per-SM occupancy (unchanged values), `device_sm_count()` reads `cudaDevAttrMultiProcessorCount` once, and the compile-time catalog `static_assert` now checks `kMinSupportedSmCount = 82` so it stays a lower bound — overshooting is what the driver rejects with `cudaErrorCooperativeLaunchTooLarge`, undershooting is only slow. The assert passes unchanged (2 × 82 = 164).

**In fairness this produces no measurable speedup today.** The route-table bounds were themselves derived from the 164-CTA budget, so `candidate_is_legal()` is an assertion on the normal path rather than a chooser. It is a correctness fix. If you ever want to widen the catalog for higher-SM parts, the recomputed bounds at 84 SMs are 896/1792/3584 (27B) and 1984/4032 (35B split4/split2) — but that means making a `constexpr` table SM-dependent and reworking the guard you deliberately built, so I did not touch it.

Also adds `DeviceContext::sm_count()`, and refreshes comments that stated device-wide totals where they meant per-SM occupancy — including one left stale by PR #4's 8-warp split4/2 retune, which still said split4/2 were register-bound to 1 CTA/SM.

### 3 & 4. ECC startup warning

ECC is off by default on GeForce, so finding it on is usually unintentional, and it looks exactly like an engine regression. Measured on this card, ECC on → off, nothing else changed: VRAM 23,028 → 24,564 MiB, sustained read bandwidth 803 → 902 GB/s (+12.3%), prefill 826 → 873 tok/s. Decode moved only +0.5%, so the warning states capacity and bandwidth rather than claiming a decode effect. The check sits in `GenerationService` because the `apps/` targets compile without CUDA include dirs.

---

### Measurements, if useful for `docs/performance.md`

That file is currently all RTX 5090 + Qwen3.6, with no Linux table. Everything below is Qwen3.8-27B, INT8 KV, CUDA Graphs, `--lm-head-draft`, 8192 context, ECC off, desktop running.

The thing that surprised me is how strongly throughput tracks MTP acceptance, which is content-dependent. Round time is essentially constant (~49.7 ms); only accepted tokens per round move:

| prompt | drafts | acceptance | decode |
|---|---:|---:|---:|
| creative prose essay | 3 | 41.0% | 44.8 tok/s |
| Python function | 3 | 53.9% | 52.5 tok/s |
| repeat a sentence 80x | 3 | 78.5% | 66.6 tok/s |
| count to 400 | 3 | 96.3% | 77.2 tok/s |
| count to 400 | 5 | 94.5% | **88.0 tok/s** |

So 88.0 tok/s on a 3090 Ti, above the published 71.0 — but 44.8 on prose with the same settings. Also: the optimum draft count inverts by content. For code the best is 3 (53.7 tok/s; 4 and 5 are *worse*, 44.3 and 45.2, because acceptance collapses 76% → 38%). For predictable output 5 is best. `mtp_num_hidden_layers: 1` explains it — drafts 2..n are one head fed its own output, so error compounds.

Real agentic traffic is the happy case: driving an `opencode` session (34 tool definitions, ~15k-token prompts) gave 72.2 / 72.7 / 89.4 tok/s at 86–100% acceptance, with prefix reuse taking TTFT from 17.8 s cold to 171 ms warm. Tool calls parsed cleanly, no malformed arguments.

One number I could not explain: non-speculative decode is 31.0 ms/pass against a 19.8 ms memory roofline (17.90 GB ÷ 902 GB/s measured), i.e. 64% of roofline, where llama.cpp reaches ~83% on the same card and model. That gap may be worth a look.

Two more RTX 5090 constants survive in live sm_86 paths, which I am reporting rather than patching since the occupancy figures behind them were measured on Blackwell and I would just be substituting another literal: `src/ops/launcher/rope.cu:16` (`kLargeBlockWaveCapacity = 1020`, i.e. 170 SMs × 6) and `src/ops/linear_attention/gated_delta_net/chunked/output.cu:9` (`kRtx5090SmCount = 170`, `kTargetCtas = 680`). `tools/hbm_bandwidth_probe.cu` also prints the 5090's 1792 GB/s as "advertised peak", which makes its "% of peak" column misleading on Ampere.

---

Lastly, and in the spirit of not wasting your time: I have moved to [syv-ai/qwen38-27b-rtx3090](https://github.com/syv-ai/qwen38-27b-rtx3090) for my own use — a vLLM-based stack for the same model and card where I measure ~125 tok/s on code generation against ~54 here. I am sending these anyway because the Dockerfile issue blocks every GeForce user on Linux and the SM-count assumption contradicts the fork's own documented support for the 3090 Ti. Thanks for doing the sm_86 port in the first place; it is a lot of work and the ReplaySSM/MTP3 memory design is genuinely clever.

Happy to split this into separate PRs if you prefer, or drop the benchmark section.
