### PR TITLE
fix(serve): cherry-pick upstream tool-call parser rewrite (fixes 0xC0000409 on tool requests)

### DIFF
--- a/src/serve/tool_call_parser.cpp
+++ b/src/serve/tool_call_parser.cpp
@@ -2,13 +2,13 @@
 
 #include <nlohmann/json.hpp>
 
-#include <algorithm>
 #include <array>
 #include <cctype>
 #include <cstdio>
 #include <random>
 #include <stdexcept>
 #include <string_view>
+#include <utility>
 
 namespace ninfer::serve {
 namespace {
@@ -37,14 +37,6 @@ void skip_ws(std::string_view text, std::size_t& pos) {
 
 bool starts_with_at(std::string_view text, std::size_t pos, std::string_view prefix) {
     return pos <= text.size() && text.substr(pos, prefix.size()) == prefix;
-}
-
-std::size_t longest_suffix_prefix(std::string_view text, std::string_view marker) {
-    const std::size_t maximum = std::min(text.size(), marker.size() - 1);
-    for (std::size_t size = maximum; size != 0; --size) {
-        if (text.substr(text.size() - size) == marker.substr(0, size)) { return size; }
-    }
-    return 0;
 }
 
 bool valid_function_name(std::string_view name, std::size_t max_name_length) {
@@ -166,29 +158,39 @@ std::string ToolCallStreamFilter::feed(std::string_view text) {
     }
 
     constexpr std::string_view kToolOpen = "<tool_call>";
-    pending_.append(text);
-    const std::size_t marker = pending_.find(kToolOpen);
-    if (marker != std::string::npos) {
-        std::size_t safe_end = marker;
-        while (safe_end != 0 &&
-               std::isspace(static_cast<unsigned char>(pending_[safe_end - 1])) != 0) {
-            --safe_end;
+    std::string visible;
+    for (std::size_t index = 0; index < text.size(); ++index) {
+        const char byte = text[index];
+        if (marker_prefix_bytes_ != 0) {
+            if (byte == kToolOpen[marker_prefix_bytes_]) {
+                ++marker_prefix_bytes_;
+                if (marker_prefix_bytes_ == kToolOpen.size()) {
+                    tool_region_ = std::move(trailing_whitespace_);
+                    trailing_whitespace_.clear();
+                    tool_region_.append(kToolOpen);
+                    tool_region_.append(text.substr(index + 1));
+                    marker_prefix_bytes_ = 0;
+                    saw_tool_marker_     = true;
+                    break;
+                }
+                continue;
+            }
+            visible.append(trailing_whitespace_);
+            trailing_whitespace_.clear();
+            visible.append(kToolOpen.substr(0, marker_prefix_bytes_));
+            marker_prefix_bytes_ = 0;
         }
-        std::string visible = pending_.substr(0, safe_end);
-        tool_region_        = pending_.substr(safe_end);
-        pending_.clear();
-        saw_tool_marker_ = true;
-        emitted_bytes_ += visible.size();
-        return visible;
-    }
 
-    const std::size_t prefix = longest_suffix_prefix(pending_, kToolOpen);
-    std::size_t safe_end     = pending_.size() - prefix;
-    while (safe_end != 0 && std::isspace(static_cast<unsigned char>(pending_[safe_end - 1])) != 0) {
-        --safe_end;
+        if (byte == kToolOpen.front()) {
+            marker_prefix_bytes_ = 1;
+        } else if (std::isspace(static_cast<unsigned char>(byte)) != 0) {
+            trailing_whitespace_.push_back(byte);
+        } else {
+            visible.append(trailing_whitespace_);
+            trailing_whitespace_.clear();
+            visible.push_back(byte);
+        }
     }
-    std::string visible = pending_.substr(0, safe_end);
-    pending_.erase(0, safe_end);
     emitted_bytes_ += visible.size();
     return visible;
 }
@@ -197,11 +199,15 @@ std::string ToolCallStreamFilter::finish(bool is_tool_call_response) {
     if (finished_) { throw std::logic_error("tool-call stream filter is already finished"); }
     finished_ = true;
     if (is_tool_call_response) {
-        pending_.clear();
+        trailing_whitespace_.clear();
         tool_region_.clear();
+        marker_prefix_bytes_ = 0;
         return {};
     }
-    std::string tail = std::move(pending_);
+    constexpr std::string_view kToolOpen = "<tool_call>";
+    std::string tail                     = std::move(trailing_whitespace_);
+    tail.append(kToolOpen.substr(0, marker_prefix_bytes_));
+    marker_prefix_bytes_ = 0;
     tail += tool_region_;
     tool_region_.clear();
     emitted_bytes_ += tail.size();

--- a/src/serve/tool_call_parser.h
+++ b/src/serve/tool_call_parser.h
@@ -29,11 +29,12 @@ public:
     [[nodiscard]] std::size_t emitted_bytes() const noexcept { return emitted_bytes_; }
 
 private:
-    std::string pending_;
+    std::string trailing_whitespace_;
     std::string tool_region_;
-    std::size_t emitted_bytes_ = 0;
-    bool saw_tool_marker_      = false;
-    bool finished_             = false;
+    std::size_t marker_prefix_bytes_ = 0;
+    std::size_t emitted_bytes_       = 0;
+    bool saw_tool_marker_            = false;
+    bool finished_                   = false;
 };
 
 } // namespace ninfer::serve

--- a/tests/test_tool_call_parser.cpp
+++ b/tests/test_tool_call_parser.cpp
@@ -144,10 +144,19 @@ int test_incremental_filter_fallback() {
     ordinary += normal.feed("ordinary text  ");
     ordinary += normal.finish(false);
 
+    const std::string partial_original = "  <tool_x then <tool_";
+    ninfer::serve::ToolCallStreamFilter partial;
+    std::string partial_restored;
+    partial_restored += partial.feed("  <too");
+    partial_restored += partial.feed("l_x then <tool_");
+    partial_restored += partial.finish(false);
+
     int failures = 0;
     failures += check(restored == original, "malformed tool filter fallback lost raw bytes");
     failures +=
         check(ordinary == "ordinary text  ", "ordinary filtered output lost trailing whitespace");
+    failures += check(partial_restored == partial_original,
+                      "partial marker mismatch did not preserve raw bytes");
     return failures;
 }
 


### PR DESCRIPTION
Cherry-picks upstream `Neroued/ninfer@1fc69e2` (*perf(serve): stream tool-call whitespace linearly*). Applies cleanly — this fork's `tool_call_parser.cpp` shares its parent.

**Bug it fixes:** on `v0.6.0-rtx3090` (prebuilt Windows archive, RTX 3090, `qwen3_8_27b.ninfer`), any request carrying function tools kills the server process — no output, exit before generation.

Repro, plain curl with 21 function tools and any prompt:

```bash
python3 -c "
import json
tools=[{'type':'function','function':{'name':f'tool_{i}','description':f'Test tool {i}',
  'parameters':{'type':'object','properties':{'path':{'type':'string'}},'required':['path']}}}
  for i in range(21)]
print(json.dumps({'model':'qwen3.8-27b','messages':[{'role':'user','content':'say hi briefly'}],
  'max_tokens':64,'stream':False,'tools':tools,'tool_choice':'auto'}))" > req.json

curl -s http://127.0.0.1:8080/v1/chat/completions -H 'Content-Type: application/json' -d @req.json
```

Before: 10/10 crashes with tools (streaming and non-streaming); 10/10 clean with the same prompt and no `tools`.

```
Faulting module: ucrtbase.dll 10.0.26100.8875
Exception code:  0xC0000409   (STATUS_STACK_BUFFER_OVERRUN)
Fault offset:    0x00000000000a527e     (identical every crash)
```

After this change: 15/15 clean — repro above, streaming variant, and a real agent client sending 21 tools. Decode speed unchanged, ~69 tok/s at C1 (INT8 KV, MTP3, 128K context).

**Unrelated build note** while reproducing: `ninfer-serve` fails to link with `VCPKG_TARGET_TRIPLET=x64-windows-static` (`LNK2038: MT_StaticRelease vs MD_DynamicRelease`); `x64-windows` works, matching the `/MD` comment in CMakeLists. `ninfer` links either way, so a partial build looks successful.
