### PR TITLE
Render mid-conversation system turns in place so prefix reuse survives Claude Code sessions

### DIFF
--- a/src/serve/anthropic_schema.cpp
+++ b/src/serve/anthropic_schema.cpp
@@ -361,9 +361,18 @@ void parse_messages(const Json& body, GenerationRequest& out, std::string& syste
         const Json& content = item.at("content");
         if (role == "system") {
             // Claude Code injects system reminders as system-role messages inside
-            // the messages array. Fold them into the leading system block: the Qwen
-            // chat template only honors leading system turns and drops the rest.
-            append_text(system_text, flatten_system_value(content, "messages"));
+            // the messages array. Leading ones merge into the system block; later
+            // ones must stay in place - hoisting content from the newest turn to
+            // the top of the prompt invalidates the whole prefix cache every turn.
+            if (out.messages.empty()) {
+                append_text(system_text, flatten_system_value(content, "messages"));
+            } else {
+                ChatTurn turn;
+                turn.role = "system";
+                turn.content.push_back(ContentPart{
+                    ContentKind::Text, flatten_system_value(content, "messages"), "text"});
+                out.messages.push_back(std::move(turn));
+            }
             continue;
         }
         if (content.is_string()) {

--- a/src/targets/qwen3_6/impl/frontend/chat_template.cpp
+++ b/src/targets/qwen3_6/impl/frontend/chat_template.cpp
@@ -351,14 +351,24 @@ RenderedChat CompiledChatTemplate::render(const std::vector<ChatMessage>& messag
     for (std::size_t i = 0; i < messages.size(); ++i) {
         const ChatMessage& message = messages[i];
         if (i < num_sys) { continue; }
-        if (message.role == "system") {
-            throw std::invalid_argument("system message must be at the beginning");
-        }
         if (!is_allowed_role(message.role)) {
             throw std::invalid_argument("unsupported chat role: " + message.role);
         }
         const std::string content = trim_ascii_whitespace(
             message.rendered_content(options.add_vision_id, &image_count, &video_count));
+        if (message.role == "system") {
+            if (message.has_media()) {
+                throw std::invalid_argument("system message cannot contain images or videos");
+            }
+            // Mid-conversation system turn (e.g. Claude Code per-turn reminders).
+            // Rendered in place so earlier prompt bytes stay stable for prefix reuse;
+            // hoisting these to the leading system block rewrites the prompt head on
+            // every turn and defeats KV caching entirely.
+            rendered += "<|im_start|>system\n";
+            rendered += content;
+            rendered += "<|im_end|>\n";
+            continue;
+        }
         if (message.role == "user") {
             rendered += "<|im_start|>user\n";
             rendered += content;

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -335,12 +335,6 @@ int test_official_chat_template() {
                               no_generation);
                       }),
                       "direct developer role was accepted by the model frontend");
-    failures +=
-        check(throws_invalid_argument([&] {
-                  (void)render_chat({chat_message("user", "hi"), chat_message("system", "late")},
-                                    no_generation);
-              }),
-              "late system role was accepted by the model frontend");
     failures += check(throws_invalid_argument([&] {
                           (void)render_chat({chat_message("system", "only")}, no_generation);
                       }),
@@ -351,6 +345,29 @@ int test_official_chat_template() {
                                     no_generation);
               }),
               "unexpected chat role was accepted");
+    return failures;
+}
+
+int test_mid_conversation_system_render() {
+    int failures = 0;
+    fi::ChatRenderOptions no_generation;
+    no_generation.add_generation_prompt = false;
+    // A system turn after the first non-system message renders in place. Hoisting
+    // it into the leading block would change the start of the rendered prompt on
+    // every turn, which invalidates any prefix cache built on earlier requests.
+    failures += check(
+        render_chat_text({chat_message("user", "hello"), chat_message("system", "reminder")},
+                         no_generation) == "<|im_start|>user\nhello<|im_end|>\n"
+                                           "<|im_start|>system\nreminder<|im_end|>\n",
+        "mid-conversation system turn was not rendered in place");
+    failures += check(
+        render_chat_text({chat_message("system", "lead"), chat_message("user", "hello"),
+                          chat_message("system", "reminder"), chat_message("user", "next")},
+                         no_generation) == "<|im_start|>system\nlead<|im_end|>\n"
+                                           "<|im_start|>user\nhello<|im_end|>\n"
+                                           "<|im_start|>system\nreminder<|im_end|>\n"
+                                           "<|im_start|>user\nnext<|im_end|>\n",
+        "leading system merges while later system turns stay in place");
     return failures;
 }
 
@@ -810,6 +827,7 @@ int main() {
     int failures                  = 0;
     failures += test_official_tokenizer_merge();
     failures += test_official_chat_template();
+    failures += test_mid_conversation_system_render();
     failures += test_reasoning_effort_chat_template();
     failures += test_turn_rewrite_trace();
     failures += test_official_resource_guards();

--- a/tests/test_anthropic_schema.cpp
+++ b/tests/test_anthropic_schema.cpp
@@ -151,7 +151,7 @@ int test_parse_system_array_and_blocks() {
 // field). Earlier we rejected those with 400 "message role must be 'user' or
 // 'assistant'". They must instead fold into the single leading system turn so the
 // Qwen template (which drops non-leading system turns) keeps the content.
-int test_system_role_in_messages_folds() {
+int test_system_role_in_messages_placement() {
     int failures    = 0;
     const Json body = {
         {"model", "m"},
@@ -162,15 +162,22 @@ int test_system_role_in_messages_folds() {
                          Json{{"role", "system"}, {"content", "reminder from messages"}},
                      })}};
     const GenerationRequest req = parse_messages_request(body, default_limits());
-    // Exactly one leading system turn (top-level + in-array folded), then the user.
-    failures += check(req.messages.size() == 2, "system folded, user kept");
-    failures += check(req.messages[0].role == "system", "single leading system turn");
-    failures += check(req.messages[0].content[0].text == "top-level system\nreminder from messages",
-                      "top-level + in-array system merged in order");
+    // The top-level system value stays the single leading system turn. A
+    // system-role message that arrives after the conversation has started must
+    // keep its position: folding it into the leading block rewrites the head of
+    // the prompt on every request and defeats prefix reuse (Claude Code appends
+    // a fresh reminder like this on every turn).
+    failures += check(req.messages.size() == 3, "leading system, user, in-place reminder");
+    failures += check(req.messages[0].role == "system" &&
+                          req.messages[0].content[0].text == "top-level system",
+                      "top-level system leads");
     failures += check(req.messages[1].role == "user" && req.messages[1].content[0].text == "hello",
                       "user turn preserved");
+    failures += check(req.messages[2].role == "system" &&
+                          req.messages[2].content[0].text == "reminder from messages",
+                      "in-array reminder stays in place");
 
-    // Also works with array-of-text-blocks content and no top-level system.
+    // Array-of-text-blocks content, no top-level system.
     const Json blocks_body = {
         {"model", "m"},
         {"max_tokens", 16},
@@ -180,9 +187,25 @@ int test_system_role_in_messages_folds() {
                               {"content", Json::array({Json{{"type", "text"}, {"text", "r"}}})}},
                      })}};
     const GenerationRequest breq = parse_messages_request(blocks_body, default_limits());
-    failures += check(breq.messages.size() == 2 && breq.messages[0].role == "system" &&
-                          breq.messages[0].content[0].text == "r",
-                      "in-array system text block folded without top-level system");
+    failures += check(breq.messages.size() == 2 && breq.messages[0].role == "user" &&
+                          breq.messages[1].role == "system" &&
+                          breq.messages[1].content[0].text == "r",
+                      "block-content reminder stays in place");
+
+    // System-role messages before the first user/assistant turn still fold.
+    const Json lead_body = {
+        {"model", "m"},
+        {"max_tokens", 16},
+        {"messages", Json::array({
+                         Json{{"role", "system"}, {"content", "a"}},
+                         Json{{"role", "system"}, {"content", "b"}},
+                         Json{{"role", "user"}, {"content", "hi"}},
+                     })}};
+    const GenerationRequest lreq = parse_messages_request(lead_body, default_limits());
+    failures += check(lreq.messages.size() == 2 && lreq.messages[0].role == "system" &&
+                          lreq.messages[0].content[0].text == "a\nb" &&
+                          lreq.messages[1].role == "user",
+                      "leading in-array system messages fold in order");
     return failures;
 }
 
@@ -650,7 +673,7 @@ int main() {
     int failures = 0;
     failures += test_parse_basic_and_system();
     failures += test_parse_system_array_and_blocks();
-    failures += test_system_role_in_messages_folds();
+    failures += test_system_role_in_messages_placement();
     failures += test_missing_and_bad_fields();
     failures += test_parse_image();
     failures += test_tools_and_choice();


### PR DESCRIPTION
I was running Claude Code against ninfer-serve on a 3090 and every turn of a session came back with reuse=full_reset and a 30 to 90 second TTFT, even though consecutive requests were byte-identical up to the appended messages. Decode speed was fine, so long sessions still felt like 8 tok/s overall.

I captured request pairs with a logging proxy and diffed the rendered prompts. The cause is the fold in anthropic_schema.cpp. Claude Code appends a system-role message with a fresh token budget line on every request, and the serving layer folds all system-role messages into the leading system block. The head of the rendered prompt therefore changes on each turn and prefix_matches can never succeed. The fold exists because the chat template throws on system turns that appear after the first non-system message.

This change makes the template render later system turns in place as ordinary im_start system blocks and keeps the fold only for messages that arrive before the conversation starts. That matches how the reference Jinja template treats the same input. Media in a late system turn is rejected the same way the leading merge rejects it.

Validation on the 3090 with the Qwen3.8-27B artifact: a live Claude Code session went from full_reset with ttft around 28 to 45s on every turn to append_frontier and restore_turn_checkpoint at 0.2 to 2s, with identical answers. A needle check on a 30k token conversation retrieved planted facts verbatim after the change. ninfer_anthropic_schema_test, ninfer_qwen3_6_frontend_test, ninfer_openai_schema_test and ninfer_tool_call_parser_test pass. I updated the schema test that pinned the old folding contract, removed the frontend assertion that expected late system turns to throw and added coverage for the new placement in both files. The NVFP4 kernel tests still fail on my machine because they want an sm_120a GPU, which a 3090 is not, so I could not run those.

One note for review: I could not find a client that depends on the old hoisting behaviour, but if you would rather gate the in-place rendering behind a flag I can rework it that way.
