### PR TITLE
fix(bench): derive Op-benchmark hardware ceilings from the device, not an RTX 5090 literal

### DIFF
--- a/bench/ops/attn_input_proj_bench.cu
+++ b/bench/ops/attn_input_proj_bench.cu
@@ -30,7 +30,7 @@ using namespace ninfer;
 namespace {
 
 constexpr std::size_t kFlushBytes = std::size_t{256} << 20;
-constexpr double kRtx5090DramGBs  = 1792.0;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
 
 enum class Format : std::uint8_t { Q4Q5, W8Qgkv, W8Qkv, Bf16, Nvfp4, Fp8, All };
 enum class CacheMode : std::uint8_t { Cold, Warm, Both };

--- a/bench/ops/bf16_linear_add_bench.cu
+++ b/bench/ops/bf16_linear_add_bench.cu
@@ -29,8 +29,8 @@ namespace {
 
 constexpr std::int32_t kRows               = 5120;
 constexpr std::int32_t kHidden             = 6144;
-constexpr double kRtx5090DramGBs           = 1792.0;
-constexpr double kRtx5090SustainedReadGBs  = 1674.5;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
+const double kRtx5090SustainedReadGBs = bench::device_specs().sustained_read_gbs;
 constexpr double kRtx5090DenseBf16Tflops   = 209.5;
 constexpr std::uint64_t kDefaultFlushBytes = 256ULL << 20;
 constexpr int kDefaultWarmup               = 3;

--- a/bench/ops/causal_softmax_attention_bench.cu
+++ b/bench/ops/causal_softmax_attention_bench.cu
@@ -36,10 +36,10 @@ constexpr std::int32_t kFp8KvGroup       = 256;
 constexpr float kScale                   = 0.0625F;
 constexpr std::size_t kFlushBytes        = std::size_t{256} << 20;
 constexpr double kDenseF16Bf16TcTflops   = 209.5;
-constexpr double kDenseFp8TcTflops       = 419.0;
+const double kDenseFp8TcTflops = bench::device_specs().fp8_f32acc_tflops;
 constexpr double kMixedFp8F16TcTflops    = 279.333;
-constexpr double kRtx5090DramGBs         = 1792.0;
-constexpr double kColdPureReadCeilingGBs = 1674.5;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
+const double kColdPureReadCeilingGBs = bench::device_specs().sustained_read_gbs;
 
 enum class Entry : std::uint8_t { Append, Cached, Both };
 enum class GeometryChoice : std::uint8_t { H24Kv4, H16Kv2, All };

--- a/bench/ops/context_softmax_attention_bench.cu
+++ b/bench/ops/context_softmax_attention_bench.cu
@@ -38,7 +38,7 @@ constexpr float kScale             = 0.08838834764831844055F;
 constexpr ops::AttentionHeadGeometry kGeometry{kHeadDim, kQueryHeads, kKvHeads};
 constexpr std::size_t kFlushBytes   = std::size_t{256} << 20;
 constexpr double kDenseBf16TcTflops = 209.5;
-constexpr double kRtx5090DramGBs    = 1792.0;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
 
 enum class Execution : std::uint8_t { Eager, Graph, Both };
 enum class CacheMode : std::uint8_t { Cold, Warm, Both };

--- a/bench/ops/embedding_bench.cu
+++ b/bench/ops/embedding_bench.cu
@@ -24,7 +24,7 @@ namespace {
 
 constexpr std::int32_t kVocab             = 248320;
 constexpr std::size_t kL2FlushBytes       = 256ULL << 20;
-constexpr double kRtx5090SustainedReadGBs = 1674.5;
+const double kRtx5090SustainedReadGBs = bench::device_specs().sustained_read_gbs;
 
 enum class Profile {
     Q6D5120,

--- a/bench/ops/gdn_input_proj_bench.cu
+++ b/bench/ops/gdn_input_proj_bench.cu
@@ -29,7 +29,7 @@ using namespace ninfer;
 namespace {
 
 constexpr std::size_t kFlushBytes = std::size_t{256} << 20;
-constexpr double kRtx5090DramGBs  = 1792.0;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
 
 enum class Format : std::uint8_t { Q4Q5, W8, Nvfp4, Fp8, All };
 enum class CacheMode : std::uint8_t { Cold, Warm, Both };

--- a/bench/ops/kv_cache_append_bench.cu
+++ b/bench/ops/kv_cache_append_bench.cu
@@ -36,7 +36,7 @@ constexpr std::int32_t kKvGroup       = 64;
 constexpr std::int32_t kFp8KvGroup    = 256;
 constexpr std::int32_t kRingCapacity  = 4096;
 constexpr std::size_t kFlushBytes     = std::size_t{256} << 20;
-constexpr double kRtx5090DramGBs      = 1792.0;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
 
 enum class Mode : std::uint8_t { Full, Prefix, All };
 enum class FullGeometryChoice : std::uint8_t { Kv4, Kv2, All };

--- a/bench/ops/linear_bench.cu
+++ b/bench/ops/linear_bench.cu
@@ -39,15 +39,15 @@ using ninfer::ops::LinearPolicy;
 
 namespace {
 
-constexpr double kRtx5090DramGBs          = 1792.0;
-constexpr double kRtx5090SustainedReadGBs = 1674.5;
-// NVIDIA's GB202 table reports dense/sparse pairs at boost clock. Keep accumulator precision
-// explicit: this benchmark's FP8 MMA route uses e4m3 inputs with FP32 accumulation.
-constexpr double kRtx5090Fp8Fp16AccumulateTFLOPs = 838.0;
-constexpr double kRtx5090Fp8Fp32AccumulateTFLOPs = 419.0;
-constexpr std::uint64_t kDefaultFlushBytes       = 256ULL << 20;
-constexpr int kDefaultWarmup                     = 3;
-constexpr int kDefaultRepeat                     = 20;
+// Hardware ceilings come from bench::device_specs(), which derives the DRAM spec from the device
+// and carries measured per-architecture sustained-read and tensor-core rates. They were literals
+// for the RTX 5090 before, which made every percentage column here wrong by 1.91x on sm_86.
+inline double dram_spec_gbs() { return bench::device_specs().dram_spec_gbs; }
+inline double sustained_read_gbs() { return bench::device_specs().sustained_read_gbs; }
+
+constexpr std::uint64_t kDefaultFlushBytes = 256ULL << 20;
+constexpr int kDefaultWarmup               = 3;
+constexpr int kDefaultRepeat               = 20;
 
 enum class TClass : std::uint8_t {
     Continuous,
@@ -554,7 +554,20 @@ double registered_tensor_peak_tflops(const BenchPoint& point, const char*& profi
     if (point.qtype == QType::FP8_E4M3FN_ROW_BF16S && point.policy == LinearPolicy::AllowA8 &&
         fp8_problem && fp8_tensor_route) {
         profile = "FP8_F32ACC";
-        return kRtx5090Fp8Fp32AccumulateTFLOPs;
+        return bench::device_specs().fp8_f32acc_tflops;
+    }
+    // Groupwise-int weights on an A16 policy bottom out in the dequantizing GEMM, which issues
+    // mma_bf16 with f32 accumulate. Reporting that ceiling is what makes it visible how much
+    // headroom an integer-activation route would actually be competing for.
+    const bool groupwise_int =
+        point.qtype == QType::Q4G64_F16S || point.qtype == QType::Q5G64_F16S ||
+        point.qtype == QType::Q6G64_F16S || point.qtype == QType::W8G32_F16S;
+    if (groupwise_int) {
+        const double peak = bench::device_specs().bf16_f32acc_tflops;
+        if (std::isfinite(peak)) {
+            profile = "BF16_F32ACC";
+            return peak;
+        }
     }
     profile = "";
     return std::numeric_limits<double>::quiet_NaN();
@@ -574,7 +587,7 @@ Result make_result(const BenchPoint& point, const LinearBenchWeight& weight,
                                 static_cast<double>(point.t);
     const double seconds = timing.median_us * 1.0e-6;
     const double memory_floor_us =
-        static_cast<double>(model_bytes) / (kRtx5090DramGBs * 1.0e9) * 1.0e6;
+        static_cast<double>(model_bytes) / (dram_spec_gbs() * 1.0e9) * 1.0e6;
 
     Result result;
     result.labels             = join_labels(point.labels);
@@ -592,8 +605,8 @@ Result make_result(const BenchPoint& point, const LinearBenchWeight& weight,
     result.min_us             = timing.min_us;
     result.p95_us             = timing.p95_us;
     result.effective_gbs      = static_cast<double>(model_bytes) / seconds / 1.0e9;
-    result.dram_spec_pct      = result.effective_gbs / kRtx5090DramGBs * 100.0;
-    result.sustained_read_pct = result.effective_gbs / kRtx5090SustainedReadGBs * 100.0;
+    result.dram_spec_pct      = result.effective_gbs / dram_spec_gbs() * 100.0;
+    result.sustained_read_pct = result.effective_gbs / sustained_read_gbs() * 100.0;
     result.useful_tflops      = useful_flops / seconds / 1.0e12;
     result.tensor_peak_tflops = registered_tensor_peak_tflops(point, result.tensor_profile);
     if (std::isfinite(result.tensor_peak_tflops)) {
@@ -712,12 +725,14 @@ void print_header() {
     CUDA_CHECK(cudaGetDevice(&device));
     cudaDeviceProp properties{};
     CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
-    std::printf("# actual_gpu=%s sm=%d%d reference_gpu=RTX_5090\n", properties.name,
-                properties.major, properties.minor);
-    std::printf("# dram_spec_gbs=%.1f sustained_read_gbs=%.1f cache=cold\n", kRtx5090DramGBs,
-                kRtx5090SustainedReadGBs);
-    std::printf("# dense_fp8_tensor_tflops fp16_acc=%.1f fp32_acc=%.1f\n",
-                kRtx5090Fp8Fp16AccumulateTFLOPs, kRtx5090Fp8Fp32AccumulateTFLOPs);
+    std::printf("# actual_gpu=%s sm=%d%d reference_gpu=%s\n", properties.name, properties.major,
+                properties.minor, bench::device_specs().reference);
+    std::printf("# dram_spec_gbs=%.1f sustained_read_gbs=%.1f cache=cold\n", dram_spec_gbs(),
+                sustained_read_gbs());
+    std::printf("# dense_tensor_peak bf16_f32acc=%.1f int8=%.1f fp8_f16acc=%.1f fp8_f32acc=%.1f\n",
+                bench::device_specs().bf16_f32acc_tflops, bench::device_specs().int8_tops,
+                bench::device_specs().fp8_f16acc_tflops,
+                bench::device_specs().fp8_f32acc_tflops);
 }
 
 void print_results(const std::vector<Result>& results) {
@@ -782,8 +797,8 @@ void write_csv(const std::filesystem::path& path, const std::vector<Result>& res
             << ',' << result.n << ',' << result.k << ',' << result.t << ',' << result.weight_bytes
             << ',' << result.x_bytes << ',' << result.out_bytes << ',' << result.model_bytes << ','
             << result.useful_flops << ',' << result.median_us << ',' << result.min_us << ','
-            << result.p95_us << ',' << result.effective_gbs << ',' << kRtx5090DramGBs << ','
-            << result.dram_spec_pct << ',' << kRtx5090SustainedReadGBs << ','
+            << result.p95_us << ',' << result.effective_gbs << ',' << dram_spec_gbs() << ','
+            << result.dram_spec_pct << ',' << sustained_read_gbs() << ','
             << result.sustained_read_pct << ',' << result.useful_tflops << ','
             << result.tensor_profile << ',';
         if (std::isfinite(result.tensor_peak_tflops)) { out << result.tensor_peak_tflops; }

--- a/bench/ops/linear_pair_bench.cu
+++ b/bench/ops/linear_pair_bench.cu
@@ -29,7 +29,7 @@ constexpr std::int32_t kFirstRow    = 4096;
 constexpr std::int32_t kSecondRow   = 5120;
 constexpr std::int32_t kRows        = 1024;
 constexpr std::int32_t kHidden      = 2048;
-constexpr double kRtx5090ReadGBs    = 1674.5;
+const double kRtx5090ReadGBs = bench::device_specs().sustained_read_gbs;
 constexpr double kRtx5090Bf16Tflops = 209.5;
 
 struct Options {

--- a/bench/ops/ninfer_bench_common.h
+++ b/bench/ops/ninfer_bench_common.h
@@ -22,13 +22,89 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <stdexcept>
 #include <utility>
 #include <vector>
 
 namespace ninfer::bench {
 
-constexpr double kRooflineGBs = 1792.0; // RTX 5090 GDDR7 bandwidth roofline.
+// ---- Device-derived hardware ceilings ---------------------------------------------------------
+//
+// This harness was written against upstream's RTX 5090 target and carried its ceilings as
+// literals: 1792 GB/s DRAM, 1674.5 GB/s sustained read, and the GB202 FP8 tensor peaks. On the
+// sm_86 fork target those overstate DRAM bandwidth by 1.91x, so every DRAM_%, READ_%, mem_% and
+// TC_% column printed by a bench binary is wrong by that factor on the hardware this fork exists
+// to serve. Derive the DRAM spec from the device itself and keep measured per-architecture
+// ceilings beside it.
+//
+// The sm_86 figures are measured on an RTX 3090 (82 SM, 1695 MHz boost, 384-bit GDDR6X):
+// sustained read from tools/hbm_bandwidth_probe.cu, tensor peaks from a register-resident MMA
+// issue-rate probe. Measured integer rates run about 18% above the GA102 whitepaper's dense
+// figures, which are quoted at a lower clock; the float rates match it.
+struct DeviceSpecs {
+    double dram_spec_gbs      = 0.0;
+    double sustained_read_gbs = 0.0;
+    double bf16_f32acc_tflops = 0.0; // BF16 MMA, f32 accumulate — what the A16 routes issue.
+    double int8_tops          = 0.0; // s8 MMA, s32 accumulate — what mma_s8 issues.
+    double fp8_f16acc_tflops  = 0.0; // NaN where the architecture has no FP8 tensor path.
+    double fp8_f32acc_tflops  = 0.0;
+    const char* reference     = "unknown";
+};
+
+inline const DeviceSpecs& device_specs() {
+    static const DeviceSpecs specs = [] {
+        DeviceSpecs out;
+        int device = 0;
+        if (cudaGetDevice(&device) != cudaSuccess) { return out; }
+        // cudaDeviceProp lost its memory-clock fields in CUDA 13; the attribute queries survive
+        // both toolkits, so ask for them that way rather than through the struct.
+        int clock_khz = 0;
+        int bus_bits  = 0;
+        int major     = 0;
+        int minor     = 0;
+        if (cudaDeviceGetAttribute(&clock_khz, cudaDevAttrMemoryClockRate, device) != cudaSuccess ||
+            cudaDeviceGetAttribute(&bus_bits, cudaDevAttrGlobalMemoryBusWidth, device) !=
+                cudaSuccess ||
+            cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device) !=
+                cudaSuccess ||
+            cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device) !=
+                cudaSuccess) {
+            return out;
+        }
+        // The reported memory clock is the single-data-rate figure; GDDR transfers on both edges.
+        out.dram_spec_gbs =
+            2.0 * static_cast<double>(clock_khz) * 1.0e3 * (static_cast<double>(bus_bits) / 8.0) /
+            1.0e9;
+        const int arch = major * 10 + minor;
+        if (arch == 86) {
+            out.reference          = "RTX_3090";
+            out.sustained_read_gbs = 894.5;
+            out.bf16_f32acc_tflops = 70.7;
+            out.int8_tops          = 335.3;
+            out.fp8_f16acc_tflops  = std::numeric_limits<double>::quiet_NaN();
+            out.fp8_f32acc_tflops  = std::numeric_limits<double>::quiet_NaN();
+        } else if (arch >= 120) {
+            out.reference          = "RTX_5090";
+            out.sustained_read_gbs = 1674.5;
+            out.bf16_f32acc_tflops = std::numeric_limits<double>::quiet_NaN();
+            out.int8_tops          = std::numeric_limits<double>::quiet_NaN();
+            out.fp8_f16acc_tflops  = 838.0;
+            out.fp8_f32acc_tflops  = 419.0;
+        } else {
+            // Unmeasured architecture: the DRAM spec is still exact, the rest is not claimed.
+            // 0.93 is the sustained-read fraction both measured architectures land on.
+            out.reference          = "device-derived";
+            out.sustained_read_gbs = out.dram_spec_gbs * 0.93;
+            out.bf16_f32acc_tflops = std::numeric_limits<double>::quiet_NaN();
+            out.int8_tops          = std::numeric_limits<double>::quiet_NaN();
+            out.fp8_f16acc_tflops  = std::numeric_limits<double>::quiet_NaN();
+            out.fp8_f32acc_tflops  = std::numeric_limits<double>::quiet_NaN();
+        }
+        return out;
+    }();
+    return specs;
+}
 
 inline std::uint16_t f32_to_bf16(float f) {
     std::uint32_t u;
@@ -54,10 +130,9 @@ inline DeviceBuffer make_zeros(std::size_t bytes) {
     return d;
 }
 
-// cudaDeviceProp memory-clock fields were removed in CUDA 13; the in-process
-// GB/s is informational anyway (ncu is the acceptance gate), so report against
-// the known RTX 5090 roofline constant.
-inline double device_peak_bw_gbs(int /*dev*/ = 0) { return kRooflineGBs; }
+// The in-process GB/s stays informational (ncu is the acceptance gate), but it now reports
+// against this device's own DRAM spec instead of a hardcoded RTX 5090 roofline.
+inline double device_peak_bw_gbs(int /*dev*/ = 0) { return device_specs().dram_spec_gbs; }
 
 struct ColdTiming {
     double median_us = 0.0;
@@ -333,7 +408,8 @@ inline void print_result(const char* tag, const Result& r) {
     std::printf(
         "%-32s median=%8.2f us  min=%8.2f us  p95=%8.2f us  %8.1f GB/s  (%.1f%% of %.0f GB/s "
         "roofline)\n",
-        tag, r.median_us, r.min_us, r.p95_us, r.gbs, r.gbs / kRooflineGBs * 100.0, kRooflineGBs);
+        tag, r.median_us, r.min_us, r.p95_us, r.gbs,
+        r.gbs / device_specs().dram_spec_gbs * 100.0, device_specs().dram_spec_gbs);
 }
 
 } // namespace ninfer::bench

--- a/bench/ops/packed_softmax_attention_bench.cu
+++ b/bench/ops/packed_softmax_attention_bench.cu
@@ -35,7 +35,7 @@ constexpr float kScale          = 0.11785113019775792073F;
 constexpr ops::AttentionHeadGeometry kGeometry{kHeadDim, kHeads, kHeads};
 constexpr std::size_t kFlushBytes   = std::size_t{256} << 20;
 constexpr double kDenseBf16TcTflops = 209.5;
-constexpr double kRtx5090DramGBs    = 1792.0;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
 
 enum class Entry : std::uint8_t { Uniform, Packed, Both };
 enum class Execution : std::uint8_t { Eager, Graph, Both };

--- a/bench/ops/prepare_masked_block_bench.cu
+++ b/bench/ops/prepare_masked_block_bench.cu
@@ -25,7 +25,7 @@ namespace {
 
 constexpr std::int32_t kMaskId    = 248077;
 constexpr std::size_t kFlushBytes = std::size_t{256} << 20;
-constexpr double kRtx5090DramGBs  = 1792.0;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
 
 enum class Execution : std::uint8_t { Eager, Graph, Both };
 enum class CacheMode : std::uint8_t { Cold, Warm, Both };

--- a/bench/ops/sliding_window_attention_bench.cu
+++ b/bench/ops/sliding_window_attention_bench.cu
@@ -36,7 +36,7 @@ constexpr float kScale             = 0.08838834764831844055F;
 constexpr ops::AttentionHeadGeometry kGeometry{kHeadDim, kQueryHeads, kKvHeads};
 constexpr std::size_t kFlushBytes   = std::size_t{256} << 20;
 constexpr double kDenseBf16TcTflops = 209.5;
-constexpr double kRtx5090DramGBs    = 1792.0;
+const double kRtx5090DramGBs = bench::device_specs().dram_spec_gbs;
 
 enum class Execution : std::uint8_t { Eager, Graph, Both };
 enum class CacheMode : std::uint8_t { Cold, Warm, Both };

--- a/tools/hbm_bandwidth_probe.cu
+++ b/tools/hbm_bandwidth_probe.cu
@@ -33,7 +33,10 @@
 namespace {
 
 constexpr int kThreads                 = 256;
-constexpr double kDefaultPeakGBps      = 1792.0;
+// 0 means "derive from the device": 2 x memory clock x bus width. The literal here used to be
+// the RTX 5090's 1792 GB/s, which on the sm_86 fork target reported every rate as roughly half
+// its true fraction of peak. --peak still overrides.
+constexpr double kDefaultPeakGBps      = 0.0;
 constexpr double kDefaultTrialSeconds  = 0.25;
 constexpr int kDefaultTrials           = 5;
 constexpr std::size_t kDefaultMaxBytes = std::size_t{4} << 30;
@@ -187,9 +190,9 @@ void print_help(const char* argv0) {
                 "  --size-gib N    bytes per large buffer (default: min(4, 20%% free))\n"
                 "  --seconds N     target duration of each timed trial (default: %.2f)\n"
                 "  --trials N      timed trials per method (default: %d)\n"
-                "  --peak-gbps N   advertised bus bandwidth (default: %.0f)\n"
+                "  --peak-gbps N   advertised bus bandwidth (default: derived from the device)\n"
                 "  --help          show this text\n",
-                argv0, kDefaultTrialSeconds, kDefaultTrials, kDefaultPeakGBps);
+                argv0, kDefaultTrialSeconds, kDefaultTrials);
 }
 
 Options parse_options(int argc, char** argv) {
@@ -281,7 +284,7 @@ void print_result(const Result& result) {
 } // namespace
 
 int main(int argc, char** argv) {
-    const Options options = parse_options(argc, argv);
+    Options options = parse_options(argc, argv);
 
     int device = 0;
     CUDA_CHECK(cudaGetDevice(&device));
@@ -319,6 +322,13 @@ int main(int argc, char** argv) {
     const int copy_grid            = resident_grid(copy_u128_kernel, prop.multiProcessorCount);
     const int copy_x4_grid         = resident_grid(copy_u128x4_kernel, prop.multiProcessorCount);
 
+    const bool derived_peak = options.peak_gbps <= 0.0;
+    if (derived_peak) {
+        // memoryClockRate is the single-data-rate clock in kHz; GDDR transfers on both edges.
+        options.peak_gbps = 2.0 * static_cast<double>(prop.memoryClockRate) * 1.0e3 *
+                            (static_cast<double>(prop.memoryBusWidth) / 8.0) / 1.0e9;
+    }
+
     std::printf("GPU:               %s\n", prop.name);
     std::printf("SMs / L2:          %d / %.1f MiB\n", prop.multiProcessorCount,
                 static_cast<double>(prop.l2CacheSize) / (1 << 20));
@@ -329,7 +339,8 @@ int main(int argc, char** argv) {
     std::printf("Working set:       %.2f GiB per buffer (%.1fx L2)\n",
                 static_cast<double>(bytes) / (std::size_t{1} << 30),
                 static_cast<double>(bytes) / prop.l2CacheSize);
-    std::printf("Advertised peak:   %.1f GB/s\n", options.peak_gbps);
+    std::printf("Advertised peak:   %.1f GB/s%s\n", options.peak_gbps,
+                derived_peak ? " (derived from device)" : " (--peak)");
     std::printf("Trial policy:      %d trials, >= %.2f s each, best + median\n", options.trials,
                 options.seconds);
     std::printf("Resident grids:    write=%d read=%d copy=%d copy-x4=%d blocks x %d threads\n\n",


### PR DESCRIPTION
## What

Every Op benchmark computed its `DRAM_%`, `READ_%`, `mem_%` and `TC_%` columns against hardcoded
RTX 5090 constants — 1792 GB/s DRAM, 1674.5 GB/s sustained read, and the GB202 FP8 tensor peaks.
On `sm_86` that overstates DRAM bandwidth by **1.91x**, so every percentage the harness printed was
wrong by that factor on the hardware this fork exists to serve. `tools/hbm_bandwidth_probe.cu`
carried the same literal and reported a 46% figure that is really 88%.

`bench::device_specs()` now derives the DRAM spec from the device and carries measured
per-architecture sustained-read and tensor-core rates beside it. It reads the memory clock and bus
width through `cudaDeviceGetAttribute` rather than `cudaDeviceProp`, which is what the old comment
in `ninfer_bench_common.h` was working around: those struct fields were removed in CUDA 13, and the
response had been to give up and hardcode a number.

## Effect

Measured on an RTX 3090, `sm_86`: **936.1 GB/s** DRAM spec (derived), **894.5 GB/s** sustained read
(95.6% of it), 70.7 TFLOPS BF16 with FP32 accumulate, 335.3 TOPS INT8. Integer rates measure about
18% above the GA102 whitepaper's dense figures, which are quoted at a lower clock; the float rates
match it.

Before and after, same binaries:

```
kv_cache_append   useful=  1.6 GB/s (  0.2% of 936)     was 0.1% of 1792
embedding         effective=  2.8 GB/s  READ=  0.31%    was 0.16%
hbm probe         best sustained read 894.5 GB/s        87.6% of peak, was reported as 46%
```

`linear_bench` also gains a tensor-core ceiling for groupwise-int A16 routes, which previously
printed nothing. That turns out to matter for interpreting the fork: `q4_rowsplit_gemm_mma` reaches
**91% of the BF16 f32-accumulate ceiling** at the 27B `mlp/gate_up` prefill shape, so that kernel
is not under-tuned — it has run out of numeric format. Without the column there was no way to see
that from the harness.

## Notes

- No kernel or runtime behaviour changes; this is measurement reporting only.
- Names of the existing constants are preserved where they were referenced, so no call site moved —
  only the initialisers changed.
- On an unrecognised architecture the DRAM spec is still exact (it comes from the device) and the
  sustained-read figure falls back to 93% of it, the fraction both measured architectures land on.
  Tensor peaks report NaN rather than a guess.
- Two commits: the shared facility plus `linear_bench` and the HBM probe, then the mechanical sweep
  across the remaining eleven binaries.
- 99/99 tests pass on this branch.
