### PR TITLE
feat(ops): integer-activation prefill route for the 27B MLP projections (1.22x prefill, sm_86)

### DIFF
--- a/include/ninfer/ops/linear.h
+++ b/include/ninfer/ops/linear.h
@@ -21,6 +21,11 @@ enum class LinearPolicy : std::uint8_t {
     A16Only, ///< Admit only A16 compute profiles.
     AllowA8, ///< Admit either A16 or A8 compute profiles.
     AllowA4, ///< Admit either A16 or A4 compute profiles.
+    /// Admit either A16 or integer-A8 compute profiles. Distinct from AllowA8, which selects the
+    /// FP8 activation path against FP8 weights; this one quantises activations to s8 with one
+    /// scale per weight group and feeds groupwise-int weights to the integer tensor cores. Held
+    /// to the same A8 activation allowance.
+    AllowA8Int,
 };
 
 /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -208,6 +208,7 @@ add_library(ninfer_ops STATIC
   ops/linear_swiglu/q4/q4_linear_swiglu_gemm_mma.cu
   ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
   ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+  ops/linear_swiglu/q4a8/q4a8_linear_swiglu.cu
   ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_decode.cu
   ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_small_t.cu
   ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4.cu

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,6 +209,7 @@ add_library(ninfer_ops STATIC
   ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
   ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
   ops/linear_swiglu/q4a8/q4a8_linear_swiglu.cu
+  ops/linear_swiglu/q4a8/q5a8_linear_add.cu
   ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_decode.cu
   ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_small_t.cu
   ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4.cu

--- a/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.cu
+++ b/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.cu
@@ -1,0 +1,287 @@
+#include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
+
+#include "core/device.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <stdexcept>
+
+namespace ninfer::ops::detail {
+namespace {
+
+// The registered 27B gate_up profile this route serves.
+constexpr std::int32_t kRows   = 34816;
+constexpr std::int32_t kOut    = kRows / 2; // gate rows [0,17408) then up rows [17408,34816)
+constexpr std::int32_t kCols   = 5120;
+constexpr std::int32_t kGroup  = 64;
+constexpr std::int32_t kGroups = kCols / kGroup;
+
+constexpr int kBM  = 128; // 64 gate rows plus their 64 up partners
+constexpr int kBN  = 128; // tokens
+constexpr int kBK  = 64;  // exactly one scale group, so the rescale needs no partial bookkeeping
+constexpr int kSRow = kBK + 16; // padded: 16-byte aligned for vector access, 20 words apart so the
+                                // eight rows a warp touches land in eight distinct banks
+constexpr int kThreads = 512;
+
+__device__ __forceinline__ void mma_s8(int& c0, int& c1, int& c2, int& c3, unsigned a0, unsigned a1,
+                                       unsigned a2, unsigned a3, unsigned b0, unsigned b1) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                 "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                 : "+r"(c0), "+r"(c1), "+r"(c2), "+r"(c3)
+                 : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+}
+
+// A uint4 read through a char* is emitted as four 32-bit loads unless the compiler can prove the
+// alignment, which it cannot through this pointer arithmetic.
+__device__ __forceinline__ uint4 lds128(const void* p) {
+    uint4 r;
+    const unsigned addr = static_cast<unsigned>(__cvta_generic_to_shared(p));
+    asm volatile("ld.shared.v4.u32 {%0,%1,%2,%3}, [%4];"
+                 : "=r"(r.x), "=r"(r.y), "=r"(r.z), "=r"(r.w)
+                 : "r"(addr));
+    return r;
+}
+
+// Four packed bytes hold eight codes as (low,high) nibble pairs. Codes are two's complement, so
+// flipping bit 3 of every nibble and subtracting 8 reproduces the (n^8)-8 the A16 decode uses.
+// Returns the s8 words for the pairs (b0,b1) and (b2,b3).
+__device__ __forceinline__ void unpack_q4(unsigned packed, unsigned& w0, unsigned& w1) {
+    packed ^= 0x88888888u;
+    const unsigned mask = 0x0f0f0f0fu;
+    const unsigned even = __vsub4(packed & mask, 0x08080808u);
+    const unsigned odd  = __vsub4((packed >> 4) & mask, 0x08080808u);
+    w0                  = __byte_perm(even, odd, 0x5140);
+    w1                  = __byte_perm(even, odd, 0x7362);
+}
+
+// One scale per (token, group of 64). A per-token absmax over all 5120 channels is set by whichever
+// channel is largest and starves every other one; a group of 64 confines an outlier to its own
+// group. It is also free where it is used, because the kernel already rescales once per group.
+__global__ void quantize_activations(const __nv_bfloat16* __restrict__ x, std::int32_t tokens,
+                                     std::int8_t* __restrict__ codes, __half* __restrict__ scales) {
+    const std::int32_t token = blockIdx.x;
+    if (token >= tokens) { return; }
+    for (std::int32_t g = threadIdx.x; g < kGroups; g += blockDim.x) {
+        const __nv_bfloat16* src = x + static_cast<std::size_t>(token) * kCols + g * kGroup;
+        float amax               = 0.0F;
+        for (int j = 0; j < kGroup; ++j) {
+            amax = fmaxf(amax, fabsf(__bfloat162float(src[j])));
+        }
+        amax                                                  = fmaxf(amax, 1.0e-20F);
+        scales[static_cast<std::size_t>(token) * kGroups + g] = __float2half(amax / 127.0F);
+        const float inv = 127.0F / amax;
+        std::int8_t* dst =
+            codes + static_cast<std::size_t>(token) * kCols + static_cast<std::size_t>(g) * kGroup;
+        for (int j = 0; j < kGroup; ++j) {
+            const float v = __bfloat162float(src[j]) * inv;
+            dst[j]        = static_cast<std::int8_t>(max(-127, min(127, __float2int_rn(v))));
+        }
+    }
+}
+
+__global__ __launch_bounds__(kThreads) void q4a8_swiglu_kernel(
+    const std::uint8_t* __restrict__ w_codes, const __half* __restrict__ w_scales,
+    const std::int8_t* __restrict__ x_codes, const __half* __restrict__ x_scales,
+    __nv_bfloat16* __restrict__ out, std::int32_t tokens) {
+    extern __shared__ char smem[];
+    std::int8_t* const sa  = reinterpret_cast<std::int8_t*>(smem);         // [kBM][kSRow]
+    std::int8_t* const sb  = sa + kBM * kSRow;                             // [kBN][kSRow]
+    __half* const sws      = reinterpret_cast<__half*>(sb + kBN * kSRow);  // [kBM]
+    __half* const sxs      = sws + kBM;                                    // [kBN]
+
+    const int tid    = threadIdx.x;
+    const int lane   = tid & 31;
+    const int warp   = tid >> 5;
+    const int gid    = lane >> 2; // 0..7, selects the row inside a 16-row tile
+    const int tig    = lane & 3;  // 0..3, selects the k quarter
+    const int warp_m = warp >> 2; // 0..3, one gate tile and its up partner
+    const int warp_n = warp & 3;  // 0..3, four n-tiles of 8 tokens
+
+    const int row_block = blockIdx.x * 64;   // 64 output rows per block
+    const int col_block = blockIdx.y * kBN;
+
+    // Shared rows 0..63 are the gate half, 64..127 the up half, so tile gt pairs with tile gt+4
+    // and one warp holds both -- the SwiGLU epilogue then needs no shared exchange.
+    const int ld_row = tid >> 2; // 0..127
+    const int ld_q   = tid & 3;  // 0..3, sixteen k each
+    const int w_abs_row =
+        (ld_row < 64) ? (row_block + ld_row) : (kOut + row_block + (ld_row - 64));
+    const int x_token = col_block + ld_row;
+
+    // Register-staged prefetch: the reads for group g+1 issue before the MMAs for group g, so
+    // their latency is covered by compute rather than stalling on the barrier.
+    struct Stage {
+        uint2 w;
+        uint4 x;
+        __half ws;
+        __half xs;
+    };
+    auto load_stage = [&](int g, Stage& s) {
+        s.w = *reinterpret_cast<const uint2*>(
+            w_codes + static_cast<std::size_t>(w_abs_row) * (kCols / 2) +
+            static_cast<std::size_t>(g) * (kBK / 2) + ld_q * 8);
+        s.x = *reinterpret_cast<const uint4*>(
+            x_codes + static_cast<std::size_t>(x_token) * kCols +
+            static_cast<std::size_t>(g) * kBK + ld_q * 16);
+        if (tid < kBM) {
+            const int r = (tid < 64) ? (row_block + tid) : (kOut + row_block + (tid - 64));
+            s.ws        = w_scales[static_cast<std::size_t>(r) * kGroups + g];
+        }
+        if (tid < kBN) {
+            s.xs = x_scales[static_cast<std::size_t>(col_block + tid) * kGroups + g];
+        }
+    };
+    // Shared rows hold k permuted: a thread's four MMA operand chunks for one row are the k
+    // quarters [t*4, t*4+16, t*4+32, t*4+48), so storing them adjacent turns fragment assembly
+    // into one 128-bit load per row. k = t*4 + c*16 + j maps to position t*16 + c*4 + j, which
+    // puts this thread's four k-ordered words at byte offsets ld_q*4 + {0,16,32,48}.
+    auto store_stage = [&](const Stage& s) {
+        unsigned q[4];
+        unpack_q4(s.w.x, q[0], q[1]);
+        unpack_q4(s.w.y, q[2], q[3]);
+        std::int8_t* wrow = sa + ld_row * kSRow + ld_q * 4;
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            *reinterpret_cast<unsigned*>(wrow + i * 16) = q[i];
+        }
+        const unsigned xw[4] = {s.x.x, s.x.y, s.x.z, s.x.w};
+        std::int8_t* xrow    = sb + ld_row * kSRow + ld_q * 4;
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            *reinterpret_cast<unsigned*>(xrow + i * 16) = xw[i];
+        }
+        if (tid < kBM) { sws[tid] = s.ws; }
+        if (tid < kBN) { sxs[tid] = s.xs; }
+    };
+
+    float acc[2][4][4]; // m=0 gate tile, m=1 its up partner
+#pragma unroll
+    for (int m = 0; m < 2; ++m)
+#pragma unroll
+        for (int n = 0; n < 4; ++n)
+#pragma unroll
+            for (int j = 0; j < 4; ++j) acc[m][n][j] = 0.0F;
+
+    Stage cur;
+    load_stage(0, cur);
+    store_stage(cur);
+    __syncthreads();
+
+    for (int g = 0; g < kGroups; ++g) {
+        Stage next;
+        if (g + 1 < kGroups) { load_stage(g + 1, next); }
+
+        unsigned af[2][2][4];
+        unsigned bf[4][2][2];
+#pragma unroll
+        for (int m = 0; m < 2; ++m) {
+            const int r0   = warp_m * 16 + m * 64 + gid; // gate tile, then +64 for the up partner
+            const uint4 lo = lds128(sa + r0 * kSRow + tig * 16);
+            const uint4 hi = lds128(sa + (r0 + 8) * kSRow + tig * 16);
+            af[m][0][0] = lo.x; af[m][0][1] = hi.x; af[m][0][2] = lo.y; af[m][0][3] = hi.y;
+            af[m][1][0] = lo.z; af[m][1][1] = hi.z; af[m][1][2] = lo.w; af[m][1][3] = hi.w;
+        }
+#pragma unroll
+        for (int n = 0; n < 4; ++n) {
+            const uint4 b = lds128(sb + ((warp_n * 4 + n) * 8 + gid) * kSRow + tig * 16);
+            bf[n][0][0] = b.x; bf[n][0][1] = b.y; bf[n][1][0] = b.z; bf[n][1][1] = b.w;
+        }
+#pragma unroll
+        for (int m = 0; m < 2; ++m) {
+            const int sr    = warp_m * 16 + m * 64 + gid;
+            const float ws0 = __half2float(sws[sr]);
+            const float ws1 = __half2float(sws[sr + 8]);
+#pragma unroll
+            for (int n = 0; n < 4; ++n) {
+                int s[4] = {0, 0, 0, 0};
+#pragma unroll
+                for (int ks = 0; ks < 2; ++ks) {
+                    mma_s8(s[0], s[1], s[2], s[3], af[m][ks][0], af[m][ks][1], af[m][ks][2],
+                           af[m][ks][3], bf[n][ks][0], bf[n][ks][1]);
+                }
+                const int c     = (warp_n * 4 + n) * 8 + tig * 2;
+                const float xa0 = __half2float(sxs[c]);
+                const float xa1 = __half2float(sxs[c + 1]);
+                acc[m][n][0]    = fmaf(static_cast<float>(s[0]), ws0 * xa0, acc[m][n][0]);
+                acc[m][n][1]    = fmaf(static_cast<float>(s[1]), ws0 * xa1, acc[m][n][1]);
+                acc[m][n][2]    = fmaf(static_cast<float>(s[2]), ws1 * xa0, acc[m][n][2]);
+                acc[m][n][3]    = fmaf(static_cast<float>(s[3]), ws1 * xa1, acc[m][n][3]);
+            }
+        }
+        __syncthreads();
+        if (g + 1 < kGroups) {
+            store_stage(next);
+            __syncthreads();
+        }
+    }
+
+    // Fused SwiGLU: acc[0] is a gate row, acc[1] its up partner, in the same thread's registers.
+    // out is contiguous [kOut, tokens], so element (row, col) sits at col * kOut + row.
+#pragma unroll
+    for (int n = 0; n < 4; ++n) {
+        const int c0 = col_block + (warp_n * 4 + n) * 8 + tig * 2;
+        const int r0 = row_block + warp_m * 16 + gid;
+#pragma unroll
+        for (int half = 0; half < 2; ++half) {
+            const int row  = r0 + half * 8;
+            const float g0 = acc[0][n][half * 2];
+            const float u0 = acc[1][n][half * 2];
+            const float g1 = acc[0][n][half * 2 + 1];
+            const float u1 = acc[1][n][half * 2 + 1];
+            out[static_cast<std::size_t>(c0) * kOut + row] =
+                __float2bfloat16(g0 / (1.0F + __expf(-g0)) * u0);
+            out[static_cast<std::size_t>(c0 + 1) * kOut + row] =
+                __float2bfloat16(g1 / (1.0F + __expf(-g1)) * u1);
+        }
+    }
+}
+
+} // namespace
+
+bool q4a8_swiglu_supported(const Weight& gate_up, std::int32_t tokens) {
+    return gate_up.qtype == QType::Q4G64_F16S && gate_up.layout == QuantLayout::RowSplit &&
+           gate_up.n == kRows && gate_up.k == kCols && gate_up.group == kGroup &&
+           gate_up.qdata != nullptr && gate_up.scales != nullptr && tokens >= kBN &&
+           tokens % kBN == 0;
+}
+
+std::size_t q4a8_swiglu_workspace_capacity_bytes(std::int32_t min_tokens, std::int32_t max_tokens) {
+    if (min_tokens <= 0 || max_tokens < min_tokens) {
+        throw std::invalid_argument("q4a8 swiglu workspace: invalid token interval");
+    }
+    const std::size_t t = static_cast<std::size_t>(max_tokens);
+    // s8 codes plus one FP16 scale per (token, group), each 256-aligned by the arena.
+    return ((t * kCols + 255) / 256) * 256 + ((t * kGroups * sizeof(__half) + 255) / 256) * 256;
+}
+
+void q4a8_swiglu_launch(const Tensor& x, const Weight& gate_up, Tensor& out,
+                        WorkspaceArena& workspace, cudaStream_t stream) {
+    const std::int32_t tokens = x.ne[1];
+    if (!q4a8_swiglu_supported(gate_up, tokens)) {
+        throw std::invalid_argument("q4a8 swiglu: unsupported profile");
+    }
+
+    auto scope             = workspace.scope();
+    const DeviceSpan codes = workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kCols);
+    const DeviceSpan scales =
+        workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kGroups * sizeof(__half));
+
+    quantize_activations<<<tokens, 128, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x.data), tokens,
+        reinterpret_cast<std::int8_t*>(codes.data), reinterpret_cast<__half*>(scales.data));
+
+    const dim3 grid(kOut / 64, tokens / kBN);
+    const std::size_t smem = static_cast<std::size_t>(kBM) * kSRow +
+                             static_cast<std::size_t>(kBN) * kSRow +
+                             (kBM + kBN) * sizeof(__half);
+    q4a8_swiglu_kernel<<<grid, kThreads, smem, stream>>>(
+        static_cast<const std::uint8_t*>(gate_up.qdata),
+        static_cast<const __half*>(gate_up.scales),
+        reinterpret_cast<const std::int8_t*>(codes.data),
+        reinterpret_cast<const __half*>(scales.data),
+        reinterpret_cast<__nv_bfloat16*>(out.data), tokens);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace ninfer::ops::detail

--- a/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.cu
+++ b/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.cu
@@ -239,6 +239,8 @@ __global__ __launch_bounds__(kThreads) void q4a8_swiglu_kernel(
 
 } // namespace
 
+bool q4a8_tokens_supported(std::int32_t tokens) { return tokens >= kBN && tokens % kBN == 0; }
+
 bool q4a8_swiglu_supported(const Weight& gate_up, std::int32_t tokens) {
     return gate_up.qtype == QType::Q4G64_F16S && gate_up.layout == QuantLayout::RowSplit &&
            gate_up.n == kRows && gate_up.k == kCols && gate_up.group == kGroup &&

--- a/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h
+++ b/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h
@@ -29,6 +29,10 @@ namespace ninfer::ops::detail {
 // fall through to the A16 route.
 [[nodiscard]] bool q4a8_swiglu_supported(const Weight& gate_up, std::int32_t tokens);
 
+// Token half of the admission rule, for the workspace query, which sees the profile but not
+// the Weight. A single-T capacity query must report the route that will actually run.
+[[nodiscard]] bool q4a8_tokens_supported(std::int32_t tokens);
+
 // Transient bytes this route needs for the quantised activation planes over [min,max] tokens.
 [[nodiscard]] std::size_t q4a8_swiglu_workspace_capacity_bytes(std::int32_t min_tokens,
                                                                std::int32_t max_tokens);
@@ -41,6 +45,7 @@ void q4a8_swiglu_launch(const Tensor& x, const Weight& gate_up, Tensor& out,
 // plane carrying each code's fifth bit; a code decodes as ((low4 | hbit << 4) ^ 0x10) - 0x10 over
 // [-16,15], which int8 still holds exactly.
 [[nodiscard]] bool q5a8_add_supported(const Weight& down, std::int32_t tokens);
+[[nodiscard]] bool q5a8_tokens_supported(std::int32_t tokens);
 [[nodiscard]] std::size_t q5a8_add_workspace_capacity_bytes(std::int32_t min_tokens,
                                                             std::int32_t max_tokens);
 void q5a8_add_launch(const Tensor& x, const Weight& down, Tensor& residual,

--- a/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h
+++ b/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h
@@ -37,4 +37,13 @@ namespace ninfer::ops::detail {
 void q4a8_swiglu_launch(const Tensor& x, const Weight& gate_up, Tensor& out,
                         WorkspaceArena& workspace, cudaStream_t stream);
 
+// Companion route for mlp/down, a Q5G64 row-split LinearAdd. Q5 adds an 8-byte-per-group high
+// plane carrying each code's fifth bit; a code decodes as ((low4 | hbit << 4) ^ 0x10) - 0x10 over
+// [-16,15], which int8 still holds exactly.
+[[nodiscard]] bool q5a8_add_supported(const Weight& down, std::int32_t tokens);
+[[nodiscard]] std::size_t q5a8_add_workspace_capacity_bytes(std::int32_t min_tokens,
+                                                            std::int32_t max_tokens);
+void q5a8_add_launch(const Tensor& x, const Weight& down, Tensor& residual,
+                     WorkspaceArena& workspace, cudaStream_t stream);
+
 } // namespace ninfer::ops::detail

--- a/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h
+++ b/src/ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h
@@ -1,0 +1,40 @@
+#pragma once
+//
+// Integer-activation route for the Qwen3.8/3.6-27B mlp/gate_up LinearSwiGLU, on sm_86.
+//
+// Reads the artifact's native Q4G64_F16S row-split weight with no repack: for Q4 that layout's
+// code plane is exactly row-major [n][k/2] with two codes per byte, and its scale plane exactly
+// row-major [n][k/64] FP16, so Weight::qdata and Weight::scales can be indexed directly.
+//
+// Activations are quantised to s8 with one scale per (token, group of 64) so that an outlier
+// channel can only spoil its own group, then fed to mma.m16n8k32.s32.s8.s8.s32 -- about 4.7x the
+// rate of the bf16 f32-accumulate MMA the A16 route issues on this hardware.
+//
+// This adds activation quantisation error the A16 route does not have: about 0.9% relative L2,
+// against upstream's own kA8QuantizationAllowance of 4% for A8 activation compute (see
+// tests/ops/linear/linear_test_common.cpp). It is opt-in for that reason.
+
+#include "core/arena.h"
+#include "core/tensor.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace ninfer::ops::detail {
+
+// True when this route can serve the call: the registered 27B gate_up profile, a row-split Q4G64
+// weight, and a token count the 128-wide tiling covers exactly. Partial prefill chunks and decode
+// fall through to the A16 route.
+[[nodiscard]] bool q4a8_swiglu_supported(const Weight& gate_up, std::int32_t tokens);
+
+// Transient bytes this route needs for the quantised activation planes over [min,max] tokens.
+[[nodiscard]] std::size_t q4a8_swiglu_workspace_capacity_bytes(std::int32_t min_tokens,
+                                                               std::int32_t max_tokens);
+
+// x is contiguous BF16 [k, tokens]; out is contiguous BF16 [n/2, tokens].
+void q4a8_swiglu_launch(const Tensor& x, const Weight& gate_up, Tensor& out,
+                        WorkspaceArena& workspace, cudaStream_t stream);
+
+} // namespace ninfer::ops::detail

--- a/src/ops/linear_swiglu/q4a8/q5a8_linear_add.cu
+++ b/src/ops/linear_swiglu/q4a8/q5a8_linear_add.cu
@@ -248,6 +248,8 @@ __global__ __launch_bounds__(kThreads) void q5a8_add_kernel(
 
 } // namespace
 
+bool q5a8_tokens_supported(std::int32_t tokens) { return tokens >= kBN && tokens % kBN == 0; }
+
 bool q5a8_add_supported(const Weight& down, std::int32_t tokens) {
     return down.qtype == QType::Q5G64_F16S && down.layout == QuantLayout::RowSplit &&
            down.n == kRows && down.k == kCols && down.group == kGroup && down.qdata != nullptr &&

--- a/src/ops/linear_swiglu/q4a8/q5a8_linear_add.cu
+++ b/src/ops/linear_swiglu/q4a8/q5a8_linear_add.cu
@@ -1,0 +1,294 @@
+// Integer-activation route for the 27B mlp/down LinearAdd, companion to the gate_up route.
+//
+// mlp/down is Q5G64_F16S [5120,17408] in the same artifact: a 4-bit low plane laid out exactly as
+// Q4's, an 8-byte-per-group high plane carrying each code's fifth bit, and an FP16 scale per group.
+// A code decodes as ((low4 | hbit << 4) ^ 0x10) - 0x10, two's complement over [-16,15], which int8
+// represents exactly -- so the fifth bit costs some unpack arithmetic and nothing else. The high
+// bit for code i is bit i of the high byte covering codes 8i..8i+7.
+//
+// The high plane is consumed while unpacking into shared, so it never occupies shared memory.
+
+#include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
+
+#include "core/device.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <stdexcept>
+
+namespace ninfer::ops::detail {
+namespace {
+
+constexpr std::int32_t kRows   = 5120;
+constexpr std::int32_t kCols   = 17408;
+constexpr std::int32_t kGroup  = 64;
+constexpr std::int32_t kGroups = kCols / kGroup; // 272
+
+constexpr int kBM      = 128;
+constexpr int kBN      = 128;
+constexpr int kBK      = 64;
+constexpr int kSRow    = kBK + 16;
+constexpr int kThreads = 512;
+
+__device__ __forceinline__ void mma_s8(int& c0, int& c1, int& c2, int& c3, unsigned a0, unsigned a1,
+                                       unsigned a2, unsigned a3, unsigned b0, unsigned b1) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                 "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                 : "+r"(c0), "+r"(c1), "+r"(c2), "+r"(c3)
+                 : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+}
+
+__device__ __forceinline__ uint4 lds128(const void* p) {
+    uint4 r;
+    const unsigned addr = static_cast<unsigned>(__cvta_generic_to_shared(p));
+    asm volatile("ld.shared.v4.u32 {%0,%1,%2,%3}, [%4];"
+                 : "=r"(r.x), "=r"(r.y), "=r"(r.z), "=r"(r.w)
+                 : "r"(addr));
+    return r;
+}
+
+// Spread the four low bits of `bits` into the low bit of four bytes: byte j becomes bit j.
+__device__ __forceinline__ unsigned spread4(unsigned bits) {
+    const unsigned t = bits & 0xfu;
+    return ((t) | (t << 7) | (t << 14) | (t << 21)) & 0x01010101u;
+}
+
+// Four packed bytes plus the matching high byte -> two s8 words of four codes, in k order.
+__device__ __forceinline__ void unpack_q5(unsigned packed, unsigned high, unsigned& w0,
+                                          unsigned& w1) {
+    const unsigned mask = 0x0f0f0f0fu;
+    const unsigned even = packed & mask;
+    const unsigned odd  = (packed >> 4) & mask;
+    // k order: byte j of the packed word holds code 2j (low nibble) and 2j+1 (high nibble).
+    unsigned lo0 = __byte_perm(even, odd, 0x5140); // codes 0..3
+    unsigned lo1 = __byte_perm(even, odd, 0x7362); // codes 4..7
+    // Fifth bit: code i takes bit i of the high byte.
+    lo0 |= spread4(high) << 4;
+    lo1 |= spread4(high >> 4) << 4;
+    // Five-bit two's complement: (v ^ 16) - 16, per byte.
+    w0 = __vsub4(lo0 ^ 0x10101010u, 0x10101010u);
+    w1 = __vsub4(lo1 ^ 0x10101010u, 0x10101010u);
+}
+
+__global__ void quantize_down_activations(const __nv_bfloat16* __restrict__ x, std::int32_t tokens,
+                                          std::int8_t* __restrict__ codes,
+                                          __half* __restrict__ scales) {
+    const std::int32_t token = blockIdx.x;
+    if (token >= tokens) { return; }
+    for (std::int32_t g = threadIdx.x; g < kGroups; g += blockDim.x) {
+        const __nv_bfloat16* src = x + static_cast<std::size_t>(token) * kCols + g * kGroup;
+        float amax               = 0.0F;
+        for (int j = 0; j < kGroup; ++j) {
+            amax = fmaxf(amax, fabsf(__bfloat162float(src[j])));
+        }
+        amax                                                  = fmaxf(amax, 1.0e-20F);
+        scales[static_cast<std::size_t>(token) * kGroups + g] = __float2half(amax / 127.0F);
+        const float inv  = 127.0F / amax;
+        std::int8_t* dst = codes + static_cast<std::size_t>(token) * kCols +
+                           static_cast<std::size_t>(g) * kGroup;
+        for (int j = 0; j < kGroup; ++j) {
+            const float v = __bfloat162float(src[j]) * inv;
+            dst[j]        = static_cast<std::int8_t>(max(-127, min(127, __float2int_rn(v))));
+        }
+    }
+}
+
+__global__ __launch_bounds__(kThreads) void q5a8_add_kernel(
+    const std::uint8_t* __restrict__ w_codes, const std::uint8_t* __restrict__ w_high,
+    const __half* __restrict__ w_scales, const std::int8_t* __restrict__ x_codes,
+    const __half* __restrict__ x_scales, __nv_bfloat16* __restrict__ residual,
+    std::int32_t tokens) {
+    extern __shared__ char smem[];
+    std::int8_t* const sa = reinterpret_cast<std::int8_t*>(smem);
+    std::int8_t* const sb = sa + kBM * kSRow;
+    __half* const sws     = reinterpret_cast<__half*>(sb + kBN * kSRow);
+    __half* const sxs     = sws + kBM;
+
+    const int tid    = threadIdx.x;
+    const int lane   = tid & 31;
+    const int warp   = tid >> 5;
+    const int gid    = lane >> 2;
+    const int tig    = lane & 3;
+    const int warp_m = warp >> 2;
+    const int warp_n = warp & 3;
+
+    const int row_block = blockIdx.x * kBM;
+    const int col_block = blockIdx.y * kBN;
+
+    const int ld_row = tid >> 2;
+    const int ld_q   = tid & 3;
+    const int w_row  = row_block + ld_row;
+    const int x_tok  = col_block + ld_row;
+
+    struct Stage {
+        uint2 w;
+        unsigned high; // two high bytes, one per packed word
+        uint4 x;
+        __half ws;
+        __half xs;
+    };
+    auto load_stage = [&](int g, Stage& s) {
+        s.w = *reinterpret_cast<const uint2*>(w_codes +
+                                              static_cast<std::size_t>(w_row) * (kCols / 2) +
+                                              static_cast<std::size_t>(g) * (kBK / 2) + ld_q * 8);
+        s.high = *reinterpret_cast<const std::uint16_t*>(
+            w_high + static_cast<std::size_t>(w_row) * (static_cast<std::size_t>(kGroups) * 8) +
+            static_cast<std::size_t>(g) * 8 + ld_q * 2);
+        s.x = *reinterpret_cast<const uint4*>(x_codes + static_cast<std::size_t>(x_tok) * kCols +
+                                              static_cast<std::size_t>(g) * kBK + ld_q * 16);
+        if (tid < kBM) {
+            s.ws = w_scales[static_cast<std::size_t>(row_block + tid) * kGroups + g];
+        }
+        if (tid < kBN) {
+            s.xs = x_scales[static_cast<std::size_t>(col_block + tid) * kGroups + g];
+        }
+    };
+    auto store_stage = [&](const Stage& s) {
+        unsigned q[4];
+        unpack_q5(s.w.x, s.high & 0xffu, q[0], q[1]);
+        unpack_q5(s.w.y, (s.high >> 8) & 0xffu, q[2], q[3]);
+        std::int8_t* wrow = sa + ld_row * kSRow + ld_q * 4;
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            *reinterpret_cast<unsigned*>(wrow + i * 16) = q[i];
+        }
+        const unsigned xw[4] = {s.x.x, s.x.y, s.x.z, s.x.w};
+        std::int8_t* xrow    = sb + ld_row * kSRow + ld_q * 4;
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            *reinterpret_cast<unsigned*>(xrow + i * 16) = xw[i];
+        }
+        if (tid < kBM) { sws[tid] = s.ws; }
+        if (tid < kBN) { sxs[tid] = s.xs; }
+    };
+
+    float acc[2][4][4];
+#pragma unroll
+    for (int m = 0; m < 2; ++m)
+#pragma unroll
+        for (int n = 0; n < 4; ++n)
+#pragma unroll
+            for (int j = 0; j < 4; ++j) acc[m][n][j] = 0.0F;
+
+    Stage cur;
+    load_stage(0, cur);
+    store_stage(cur);
+    __syncthreads();
+
+    for (int g = 0; g < kGroups; ++g) {
+        Stage next;
+        if (g + 1 < kGroups) { load_stage(g + 1, next); }
+
+        unsigned af[2][2][4];
+        unsigned bf[4][2][2];
+#pragma unroll
+        for (int m = 0; m < 2; ++m) {
+            const int r0   = warp_m * 32 + m * 16 + gid;
+            const uint4 lo = lds128(sa + r0 * kSRow + tig * 16);
+            const uint4 hi = lds128(sa + (r0 + 8) * kSRow + tig * 16);
+            af[m][0][0] = lo.x; af[m][0][1] = hi.x; af[m][0][2] = lo.y; af[m][0][3] = hi.y;
+            af[m][1][0] = lo.z; af[m][1][1] = hi.z; af[m][1][2] = lo.w; af[m][1][3] = hi.w;
+        }
+#pragma unroll
+        for (int n = 0; n < 4; ++n) {
+            const uint4 b = lds128(sb + ((warp_n * 4 + n) * 8 + gid) * kSRow + tig * 16);
+            bf[n][0][0] = b.x; bf[n][0][1] = b.y; bf[n][1][0] = b.z; bf[n][1][1] = b.w;
+        }
+#pragma unroll
+        for (int m = 0; m < 2; ++m) {
+            const int sr    = warp_m * 32 + m * 16 + gid;
+            const float ws0 = __half2float(sws[sr]);
+            const float ws1 = __half2float(sws[sr + 8]);
+#pragma unroll
+            for (int n = 0; n < 4; ++n) {
+                int s[4] = {0, 0, 0, 0};
+#pragma unroll
+                for (int ks = 0; ks < 2; ++ks) {
+                    mma_s8(s[0], s[1], s[2], s[3], af[m][ks][0], af[m][ks][1], af[m][ks][2],
+                           af[m][ks][3], bf[n][ks][0], bf[n][ks][1]);
+                }
+                const int c     = (warp_n * 4 + n) * 8 + tig * 2;
+                const float xa0 = __half2float(sxs[c]);
+                const float xa1 = __half2float(sxs[c + 1]);
+                acc[m][n][0]    = fmaf(static_cast<float>(s[0]), ws0 * xa0, acc[m][n][0]);
+                acc[m][n][1]    = fmaf(static_cast<float>(s[1]), ws0 * xa1, acc[m][n][1]);
+                acc[m][n][2]    = fmaf(static_cast<float>(s[2]), ws1 * xa0, acc[m][n][2]);
+                acc[m][n][3]    = fmaf(static_cast<float>(s[3]), ws1 * xa1, acc[m][n][3]);
+            }
+        }
+        __syncthreads();
+        if (g + 1 < kGroups) {
+            store_stage(next);
+            __syncthreads();
+        }
+    }
+
+    // residual is contiguous [kRows, tokens] and is the only observable mutation: each output
+    // element belongs to exactly one thread, so a plain read-add-write is safe.
+#pragma unroll
+    for (int m = 0; m < 2; ++m) {
+#pragma unroll
+        for (int n = 0; n < 4; ++n) {
+            const int c0 = col_block + (warp_n * 4 + n) * 8 + tig * 2;
+            const int r0 = row_block + warp_m * 32 + m * 16 + gid;
+#pragma unroll
+            for (int half = 0; half < 2; ++half) {
+                const int row     = r0 + half * 8;
+                const std::size_t i0 = static_cast<std::size_t>(c0) * kRows + row;
+                const std::size_t i1 = static_cast<std::size_t>(c0 + 1) * kRows + row;
+                residual[i0] = __float2bfloat16(__bfloat162float(residual[i0]) +
+                                                acc[m][n][half * 2]);
+                residual[i1] = __float2bfloat16(__bfloat162float(residual[i1]) +
+                                                acc[m][n][half * 2 + 1]);
+            }
+        }
+    }
+}
+
+} // namespace
+
+bool q5a8_add_supported(const Weight& down, std::int32_t tokens) {
+    return down.qtype == QType::Q5G64_F16S && down.layout == QuantLayout::RowSplit &&
+           down.n == kRows && down.k == kCols && down.group == kGroup && down.qdata != nullptr &&
+           down.qhigh != nullptr && down.scales != nullptr && tokens >= kBN && tokens % kBN == 0;
+}
+
+std::size_t q5a8_add_workspace_capacity_bytes(std::int32_t min_tokens, std::int32_t max_tokens) {
+    if (min_tokens <= 0 || max_tokens < min_tokens) {
+        throw std::invalid_argument("q5a8 add workspace: invalid token interval");
+    }
+    const std::size_t t = static_cast<std::size_t>(max_tokens);
+    return ((t * kCols + 255) / 256) * 256 + ((t * kGroups * sizeof(__half) + 255) / 256) * 256;
+}
+
+void q5a8_add_launch(const Tensor& x, const Weight& down, Tensor& residual,
+                     WorkspaceArena& workspace, cudaStream_t stream) {
+    const std::int32_t tokens = x.ne[1];
+    if (!q5a8_add_supported(down, tokens)) {
+        throw std::invalid_argument("q5a8 add: unsupported profile");
+    }
+
+    auto scope             = workspace.scope();
+    const DeviceSpan codes = workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kCols);
+    const DeviceSpan scales =
+        workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kGroups * sizeof(__half));
+
+    quantize_down_activations<<<tokens, 128, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x.data), tokens,
+        reinterpret_cast<std::int8_t*>(codes.data), reinterpret_cast<__half*>(scales.data));
+
+    const dim3 grid(kRows / kBM, tokens / kBN);
+    const std::size_t smem = static_cast<std::size_t>(kBM) * kSRow +
+                             static_cast<std::size_t>(kBN) * kSRow +
+                             (kBM + kBN) * sizeof(__half);
+    q5a8_add_kernel<<<grid, kThreads, smem, stream>>>(
+        static_cast<const std::uint8_t*>(down.qdata), static_cast<const std::uint8_t*>(down.qhigh),
+        static_cast<const __half*>(down.scales),
+        reinterpret_cast<const std::int8_t*>(codes.data),
+        reinterpret_cast<const __half*>(scales.data),
+        reinterpret_cast<__nv_bfloat16*>(residual.data), tokens);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace ninfer::ops::detail

--- a/src/ops/wrapper/linear_add.cpp
+++ b/src/ops/wrapper/linear_add.cpp
@@ -14,6 +14,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
+
 namespace ninfer::ops {
 namespace {
 
@@ -64,6 +66,7 @@ void validate_policy(LinearPolicy policy) {
     case LinearPolicy::A16Only:
     case LinearPolicy::AllowA8:
     case LinearPolicy::AllowA4:
+    case LinearPolicy::AllowA8Int:
         return;
     }
     throw std::invalid_argument("linear_add: invalid compute policy");
@@ -102,11 +105,20 @@ std::size_t linear_add_workspace_capacity_bytes(QType qtype, std::int32_t output
         return 0;
     }
     if (qtype == QType::Q5G64_F16S) {
-        if (policy != LinearPolicy::A16Only) {
-            throw std::invalid_argument("linear_add workspace: Q5 admits only A16");
+        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int) {
+            throw std::invalid_argument("linear_add workspace: Q5 admits A16 or integer A8");
         }
-        return detail::q5_linear_add_capacity_workspace_bytes(output_rows, input_rows, input_rows,
-                                                              min_tokens, max_tokens);
+        const std::size_t a16 = detail::q5_linear_add_capacity_workspace_bytes(
+            output_rows, input_rows, input_rows, min_tokens, max_tokens);
+        if (policy != LinearPolicy::AllowA8Int || output_rows != 5120 || input_rows != 17408) {
+            return a16;
+        }
+        if (min_tokens == max_tokens) {
+            return detail::q5a8_tokens_supported(min_tokens)
+                       ? detail::q5a8_add_workspace_capacity_bytes(min_tokens, max_tokens)
+                       : a16;
+        }
+        return std::max(a16, detail::q5a8_add_workspace_capacity_bytes(min_tokens, max_tokens));
     }
     if (qtype == QType::NVFP4) {
         const bool supported = (output_rows == detail::Nvfp4Residual6144Geometry::kOutputRows &&
@@ -168,8 +180,12 @@ void linear_add(const Tensor& x, const Weight& w, Tensor& residual_out, LinearPo
     }
 
     if (w.qtype == QType::Q5G64_F16S) {
-        if (policy != LinearPolicy::A16Only) {
-            throw std::invalid_argument("Q5 linear_add admits only A16");
+        if (policy == LinearPolicy::AllowA8Int && detail::q5a8_add_supported(w, x.ne[1])) {
+            detail::q5a8_add_launch(x, w, residual_out, ws, stream);
+            return;
+        }
+        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int) {
+            throw std::invalid_argument("Q5 linear_add admits A16 or integer A8");
         }
         require_q5(w);
         const bool supported_shape = (w.n == 5120 && w.k == 17408) || (w.n == 5120 && w.k == 6144);

--- a/src/ops/wrapper/linear_swiglu.cpp
+++ b/src/ops/wrapper/linear_swiglu.cpp
@@ -5,6 +5,7 @@
 #include "ops/linear_swiglu/fp8/fp8_linear_swiglu_plan.h"
 #include "ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.h"
 #include "ops/linear_swiglu/q4/q4_linear_swiglu_plan.h"
+#include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
 #include "ops/linear_swiglu/w8/w8_linear_swiglu_plan.h"
 
 #include <cstdint>
@@ -22,6 +23,7 @@ void validate_policy(LinearPolicy policy) {
     case LinearPolicy::A16Only:
     case LinearPolicy::AllowA8:
     case LinearPolicy::AllowA4:
+    case LinearPolicy::AllowA8Int:
         return;
     }
     throw std::invalid_argument("linear_swiglu: invalid compute policy");
@@ -48,11 +50,22 @@ std::size_t linear_swiglu_workspace_capacity_bytes(QType qtype, std::int32_t gat
         return 0;
     }
     if (qtype == QType::Q4G64_F16S) {
-        if (policy != LinearPolicy::A16Only) {
-            throw std::invalid_argument("linear_swiglu workspace: Q4 admits only A16");
+        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int) {
+            throw std::invalid_argument("linear_swiglu workspace: Q4 admits A16 or integer A8");
         }
-        return detail::q4_linear_swiglu_capacity_workspace_bytes(
+        const std::size_t a16 = detail::q4_linear_swiglu_capacity_workspace_bytes(
             gate_up_rows, gate_up_rows / 2, input_rows, input_rows, min_tokens, max_tokens);
+        if (policy != LinearPolicy::AllowA8Int || gate_up_rows != 34816 || input_rows != 5120) {
+            return a16;
+        }
+        // A single-T query must report exactly what that T will use, so it has to name the route
+        // the resolver will pick. Across an interval the answer is an upper bound over both.
+        if (min_tokens == max_tokens) {
+            return detail::q4a8_tokens_supported(min_tokens)
+                       ? detail::q4a8_swiglu_workspace_capacity_bytes(min_tokens, max_tokens)
+                       : a16;
+        }
+        return std::max(a16, detail::q4a8_swiglu_workspace_capacity_bytes(min_tokens, max_tokens));
     }
     if (qtype == QType::NVFP4 && gate_up_rows == 34816 && input_rows == 5120) {
         return detail::nvfp4_linear_swiglu_workspace_capacity_bytes(policy, min_tokens, max_tokens);
@@ -125,8 +138,13 @@ void linear_swiglu(const Tensor& x, const Weight& gate_up_weight, Tensor& out, L
         return;
     }
 
-    if (policy != LinearPolicy::A16Only) {
-        throw std::invalid_argument("linear_swiglu: Q4/W8 admit only A16");
+    if (policy == LinearPolicy::AllowA8Int && q4_weight &&
+        detail::q4a8_swiglu_supported(gate_up_weight, t)) {
+        detail::q4a8_swiglu_launch(x, gate_up_weight, out, ws, stream);
+        return;
+    }
+    if (policy != LinearPolicy::A16Only && !(policy == LinearPolicy::AllowA8Int && q4_weight)) {
+        throw std::invalid_argument("linear_swiglu: Q4 admits A16 or integer A8; W8 admits A16");
     }
     if (!aligned_to(gate_up_weight.qdata, 16) ||
         !aligned_to(gate_up_weight.scales, w8_weight ? 16 : 4)) {

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -13,6 +13,7 @@
 
 
 #include <algorithm>
+#include <cstdlib>
 #include <stdexcept>
 
 #define NINFER_QWEN36_VARIANT    ::ninfer::targets::qwen3_6_27b::detail::Variant
@@ -59,7 +60,29 @@ constexpr ops::LinearPolicy kFp8TextPolicy   = ops::LinearPolicy::AllowA8;
 constexpr ops::LinearPolicy kGroupwiseIntTextPolicy = ops::LinearPolicy::A16Only;
 #endif
 
+// PR_POLICY asks for invasive runtime changes -- custom kernels and quantization among them --
+// to arrive behind a flag and default to off until they have proven stable. The Op-level
+// registration of AllowA8Int is unconditional and fully tested; this gate only decides whether the
+// 27B target asks for it. Set NINFER_W4A8_PREFILL=1 to opt in.
+bool integer_activation_prefill_enabled() {
+    static const bool enabled = [] {
+        const char* value = std::getenv("NINFER_W4A8_PREFILL");
+        return value != nullptr && value[0] == '1' && value[1] == 0;
+    }();
+    return enabled;
+}
+
 ops::LinearPolicy text_policy(const Weight& weight) {
+    if (!integer_activation_prefill_enabled()) {
+        switch (weight.qtype) {
+        case QType::NVFP4:
+            return kNvfp4TextPolicy;
+        case QType::FP8_E4M3FN_ROW_BF16S:
+            return kFp8TextPolicy;
+        default:
+            return ops::LinearPolicy::A16Only;
+        }
+    }
     switch (weight.qtype) {
     case QType::NVFP4:
         return kNvfp4TextPolicy;

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -134,9 +134,14 @@ std::size_t post_mixer_workspace_bytes(QType gate_up_qtype, QType down_qtype,
         (void)layout.alloc_bytes(swiglu_bytes);
     }
     {
-        auto scope = layout.scope();
-        (void)layout.alloc_bytes(ops::linear_add_workspace_capacity_bytes(
-            down_qtype, TextConfig::hidden, TextConfig::intermediate, policy, first, last));
+        auto scope              = layout.scope();
+        std::size_t down_bytes  = ops::linear_add_workspace_capacity_bytes(
+            down_qtype, TextConfig::hidden, TextConfig::intermediate, policy, first, last);
+        if (q4a8_swiglu_enabled() && down_qtype == QType::Q5G64_F16S) {
+            down_bytes = std::max(down_bytes,
+                                  ops::detail::q5a8_add_workspace_capacity_bytes(first, last));
+        }
+        (void)layout.alloc_bytes(down_bytes);
     }
     return layout.peak_bytes(1);
 }
@@ -329,8 +334,12 @@ void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, 
         ops::linear_swiglu(hidden, weights.gate_up, activation, text_policy(weights.gate_up),
                            workspace, stream);
     }
-    ops::linear_add(activation, weights.down, residual, text_policy(weights.down), workspace,
-                    stream);
+    if (q4a8_swiglu_enabled() && ops::detail::q5a8_add_supported(weights.down, activation.ne[1])) {
+        ops::detail::q5a8_add_launch(activation, weights.down, residual, workspace, stream);
+    } else {
+        ops::linear_add(activation, weights.down, residual, text_policy(weights.down), workspace,
+                        stream);
+    }
 }
 
 void Variant::mtp_post_mixer(const Tensor& hidden, const MtpPostMixerWeights& weights,

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -65,12 +65,21 @@ ops::LinearPolicy text_policy(const Weight& weight) {
         return kNvfp4TextPolicy;
     case QType::FP8_E4M3FN_ROW_BF16S:
         return kFp8TextPolicy;
+    // Permissive only for the two profiles that have a registered integer route -- the MLP
+    // gate_up and down projections. The resolver then takes it on full prefill tiles and falls
+    // back to A16 everywhere else, including every decode step and every partial tile.
+    //
+    // Deliberately keyed on shape rather than qtype alone: attn_input_proj and gdn_input_proj
+    // also receive text_policy() and neither admits AllowA8Int, so handing it to them would
+    // throw. Today the groupwise-int artifact reaches those through their split payloads, which
+    // pass no policy at all, so a broader rule happens not to fire -- but that is luck, not
+    // design, and the fused payloads would hit it.
     case QType::Q4G64_F16S:
+        return (weight.n == 34816 && weight.k == 5120) ? kGroupwiseIntTextPolicy
+                                                        : ops::LinearPolicy::A16Only;
     case QType::Q5G64_F16S:
-        // Permissive: the Op resolver takes the integer-activation route where it is registered
-        // and falls back to A16 everywhere else, which is every decode step and every partial
-        // prefill tile. Held to the A8 activation allowance.
-        return kGroupwiseIntTextPolicy;
+        return (weight.n == 5120 && weight.k == 17408) ? kGroupwiseIntTextPolicy
+                                                        : ops::LinearPolicy::A16Only;
     default:
         return ops::LinearPolicy::A16Only;
     }

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -11,6 +11,10 @@
 #include "ninfer/ops/residual_add.h"
 #include "ninfer/ops/silu_mul.h"
 
+#include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
+
+#include <cstdlib>
+
 #include <algorithm>
 #include <stdexcept>
 
@@ -102,6 +106,18 @@ std::size_t gdn_record_workspace_bytes(const Tensor& hidden,
             parent.qtype, parent.n, parent.k, text_policy(parent), batch, width, width));
 }
 
+// Opt-in integer-activation route for the MLP gate_up projection. It trades roughly 0.9%
+// relative L2 on that projection -- well inside upstream's own 4% A8 activation allowance -- for
+// about twice the prefill GEMM rate, and only engages on full 128-token prefill tiles, so decode
+// and partial chunks keep the A16 route untouched.
+bool q4a8_swiglu_enabled() {
+    static const bool enabled = [] {
+        const char* v = std::getenv("NINFER_W4A8_PREFILL");
+        return v != nullptr && v[0] == '1' && v[1] == '\0';
+    }();
+    return enabled;
+}
+
 std::size_t post_mixer_workspace_bytes(QType gate_up_qtype, QType down_qtype,
                                        ops::LinearPolicy policy, std::int32_t first,
                                        std::int32_t last) {
@@ -109,8 +125,13 @@ std::size_t post_mixer_workspace_bytes(QType gate_up_qtype, QType down_qtype,
     (void)layout.alloc(DType::BF16, {TextConfig::intermediate, last});
     {
         auto scope = layout.scope();
-        (void)layout.alloc_bytes(ops::linear_swiglu_workspace_capacity_bytes(
-            gate_up_qtype, 2 * TextConfig::intermediate, TextConfig::hidden, policy, first, last));
+        std::size_t swiglu_bytes = ops::linear_swiglu_workspace_capacity_bytes(
+            gate_up_qtype, 2 * TextConfig::intermediate, TextConfig::hidden, policy, first, last);
+        if (q4a8_swiglu_enabled() && gate_up_qtype == QType::Q4G64_F16S) {
+            swiglu_bytes = std::max(
+                swiglu_bytes, ops::detail::q4a8_swiglu_workspace_capacity_bytes(first, last));
+        }
+        (void)layout.alloc_bytes(swiglu_bytes);
     }
     {
         auto scope = layout.scope();
@@ -302,8 +323,12 @@ void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, 
                          qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream) {
     auto scope        = workspace.scope();
     Tensor activation = workspace.alloc(DType::BF16, {TextConfig::intermediate, hidden.ne[1]});
-    ops::linear_swiglu(hidden, weights.gate_up, activation, text_policy(weights.gate_up), workspace,
-                       stream);
+    if (q4a8_swiglu_enabled() && ops::detail::q4a8_swiglu_supported(weights.gate_up, hidden.ne[1])) {
+        ops::detail::q4a8_swiglu_launch(hidden, weights.gate_up, activation, workspace, stream);
+    } else {
+        ops::linear_swiglu(hidden, weights.gate_up, activation, text_policy(weights.gate_up),
+                           workspace, stream);
+    }
     ops::linear_add(activation, weights.down, residual, text_policy(weights.down), workspace,
                     stream);
 }

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -11,9 +11,6 @@
 #include "ninfer/ops/residual_add.h"
 #include "ninfer/ops/silu_mul.h"
 
-#include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
-
-#include <cstdlib>
 
 #include <algorithm>
 #include <stdexcept>
@@ -52,9 +49,14 @@ void validate_token_interval(std::int32_t first, std::int32_t last) {
 // through their A16 routes, which dequantize the stored codes to BF16 before the MMA.
 constexpr ops::LinearPolicy kNvfp4TextPolicy = ops::LinearPolicy::A16Only;
 constexpr ops::LinearPolicy kFp8TextPolicy   = ops::LinearPolicy::A16Only;
+// The integer-activation route for groupwise-int weights is an sm_86 addition: it feeds the s8
+// tensor cores, which Ampere has and which no A16 route uses.
+constexpr ops::LinearPolicy kGroupwiseIntTextPolicy = ops::LinearPolicy::AllowA8Int;
 #else
 constexpr ops::LinearPolicy kNvfp4TextPolicy = ops::LinearPolicy::AllowA4;
 constexpr ops::LinearPolicy kFp8TextPolicy   = ops::LinearPolicy::AllowA8;
+// Not built for sm_120a; groupwise-int keeps its A16 route there.
+constexpr ops::LinearPolicy kGroupwiseIntTextPolicy = ops::LinearPolicy::A16Only;
 #endif
 
 ops::LinearPolicy text_policy(const Weight& weight) {
@@ -63,6 +65,12 @@ ops::LinearPolicy text_policy(const Weight& weight) {
         return kNvfp4TextPolicy;
     case QType::FP8_E4M3FN_ROW_BF16S:
         return kFp8TextPolicy;
+    case QType::Q4G64_F16S:
+    case QType::Q5G64_F16S:
+        // Permissive: the Op resolver takes the integer-activation route where it is registered
+        // and falls back to A16 everywhere else, which is every decode step and every partial
+        // prefill tile. Held to the A8 activation allowance.
+        return kGroupwiseIntTextPolicy;
     default:
         return ops::LinearPolicy::A16Only;
     }
@@ -106,18 +114,6 @@ std::size_t gdn_record_workspace_bytes(const Tensor& hidden,
             parent.qtype, parent.n, parent.k, text_policy(parent), batch, width, width));
 }
 
-// Opt-in integer-activation route for the MLP gate_up projection. It trades roughly 0.9%
-// relative L2 on that projection -- well inside upstream's own 4% A8 activation allowance -- for
-// about twice the prefill GEMM rate, and only engages on full 128-token prefill tiles, so decode
-// and partial chunks keep the A16 route untouched.
-bool q4a8_swiglu_enabled() {
-    static const bool enabled = [] {
-        const char* v = std::getenv("NINFER_W4A8_PREFILL");
-        return v != nullptr && v[0] == '1' && v[1] == '\0';
-    }();
-    return enabled;
-}
-
 std::size_t post_mixer_workspace_bytes(QType gate_up_qtype, QType down_qtype,
                                        ops::LinearPolicy policy, std::int32_t first,
                                        std::int32_t last) {
@@ -125,23 +121,13 @@ std::size_t post_mixer_workspace_bytes(QType gate_up_qtype, QType down_qtype,
     (void)layout.alloc(DType::BF16, {TextConfig::intermediate, last});
     {
         auto scope = layout.scope();
-        std::size_t swiglu_bytes = ops::linear_swiglu_workspace_capacity_bytes(
-            gate_up_qtype, 2 * TextConfig::intermediate, TextConfig::hidden, policy, first, last);
-        if (q4a8_swiglu_enabled() && gate_up_qtype == QType::Q4G64_F16S) {
-            swiglu_bytes = std::max(
-                swiglu_bytes, ops::detail::q4a8_swiglu_workspace_capacity_bytes(first, last));
-        }
-        (void)layout.alloc_bytes(swiglu_bytes);
+        (void)layout.alloc_bytes(ops::linear_swiglu_workspace_capacity_bytes(
+            gate_up_qtype, 2 * TextConfig::intermediate, TextConfig::hidden, policy, first, last));
     }
     {
         auto scope              = layout.scope();
-        std::size_t down_bytes  = ops::linear_add_workspace_capacity_bytes(
-            down_qtype, TextConfig::hidden, TextConfig::intermediate, policy, first, last);
-        if (q4a8_swiglu_enabled() && down_qtype == QType::Q5G64_F16S) {
-            down_bytes = std::max(down_bytes,
-                                  ops::detail::q5a8_add_workspace_capacity_bytes(first, last));
-        }
-        (void)layout.alloc_bytes(down_bytes);
+        (void)layout.alloc_bytes(ops::linear_add_workspace_capacity_bytes(
+            down_qtype, TextConfig::hidden, TextConfig::intermediate, policy, first, last));
     }
     return layout.peak_bytes(1);
 }
@@ -328,18 +314,10 @@ void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, 
                          qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream) {
     auto scope        = workspace.scope();
     Tensor activation = workspace.alloc(DType::BF16, {TextConfig::intermediate, hidden.ne[1]});
-    if (q4a8_swiglu_enabled() && ops::detail::q4a8_swiglu_supported(weights.gate_up, hidden.ne[1])) {
-        ops::detail::q4a8_swiglu_launch(hidden, weights.gate_up, activation, workspace, stream);
-    } else {
-        ops::linear_swiglu(hidden, weights.gate_up, activation, text_policy(weights.gate_up),
-                           workspace, stream);
-    }
-    if (q4a8_swiglu_enabled() && ops::detail::q5a8_add_supported(weights.down, activation.ne[1])) {
-        ops::detail::q5a8_add_launch(activation, weights.down, residual, workspace, stream);
-    } else {
-        ops::linear_add(activation, weights.down, residual, text_policy(weights.down), workspace,
-                        stream);
-    }
+    ops::linear_swiglu(hidden, weights.gate_up, activation, text_policy(weights.gate_up), workspace,
+                       stream);
+    ops::linear_add(activation, weights.down, residual, text_policy(weights.down), workspace,
+                    stream);
 }
 
 void Variant::mtp_post_mixer(const Tensor& hidden, const MtpPostMixerWeights& weights,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -348,6 +348,9 @@ ninfer_add_fused_linear_test(
   ninfer_linear_swiglu_fp8_test
   ops/linear_swiglu/test_fp8.cpp
   ops/linear_swiglu/linear_swiglu_test_common.cpp)
+ninfer_add_op_test(ninfer_linear_swiglu_q4a8_int_test
+  SOURCES ops/linear_swiglu/test_q4a8_int.cpp
+  LIBRARIES ninfer_ops)
 
 ninfer_add_test(ninfer_qwen3_6_27b_visual_scatter_test
   SOURCES targets/qwen3_6_27b/test_visual_scatter.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -348,6 +348,10 @@ ninfer_add_fused_linear_test(
   ninfer_linear_swiglu_fp8_test
   ops/linear_swiglu/test_fp8.cpp
   ops/linear_swiglu/linear_swiglu_test_common.cpp)
+ninfer_add_fused_linear_test(
+  ninfer_linear_swiglu_q4_a8int_test
+  ops/linear_swiglu/test_q4_a8int.cpp
+  ops/linear_swiglu/linear_swiglu_test_common.cpp)
 ninfer_add_op_test(ninfer_linear_swiglu_q4a8_int_test
   SOURCES ops/linear_swiglu/test_q4a8_int.cpp
   LIBRARIES ninfer_ops)

--- a/tests/ops/linear_swiglu/linear_swiglu_test_common.cpp
+++ b/tests/ops/linear_swiglu/linear_swiglu_test_common.cpp
@@ -35,6 +35,11 @@ constexpr ReductionCriterion tolerance_for(ActivationCompute activation_compute)
         // Both independently A8-quantized projections feed the nonlinear product, so this profile
         // allows twice Linear's relative-L2 quantization allowance plus a bounded gross tail.
         return {8.0e-2, 1.0e-2, 1.2e-1};
+    case ActivationCompute::A8Int:
+        // Same structure as A8: gate and up are each quantized independently before feeding the
+        // nonlinear product, so the same allowance applies. Only the activation format differs --
+        // s8 with one scale per weight group rather than FP8.
+        return {8.0e-2, 1.0e-2, 1.2e-1};
     case ActivationCompute::A4:
         return {1.6e-1, 1.0e-2, 1.6e-1};
     }
@@ -231,7 +236,8 @@ void validate_profile(const Profile& profile) {
          profile.activation_compute != ActivationCompute::A4) ||
         (fp8 && profile.activation_compute != ActivationCompute::A16 &&
          profile.activation_compute != ActivationCompute::A8) ||
-        (!nvfp4 && !fp8 && profile.activation_compute != ActivationCompute::A16)) {
+        (!nvfp4 && !fp8 && profile.activation_compute != ActivationCompute::A16 &&
+         profile.activation_compute != ActivationCompute::A8Int)) {
         throw std::invalid_argument("linear_swiglu test: invalid activation-compute profile");
     }
 }
@@ -278,8 +284,11 @@ int run_profile(std::string_view label, const Profile& profile,
     const ops::LinearPolicy policy =
         profile.activation_compute == ActivationCompute::A4
             ? ops::LinearPolicy::AllowA4
-            : (profile.activation_compute == ActivationCompute::A8 ? ops::LinearPolicy::AllowA8
-                                                                   : ops::LinearPolicy::A16Only);
+            : (profile.activation_compute == ActivationCompute::A8
+                   ? ops::LinearPolicy::AllowA8
+                   : (profile.activation_compute == ActivationCompute::A8Int
+                          ? ops::LinearPolicy::AllowA8Int
+                          : ops::LinearPolicy::A16Only));
     const std::size_t workspace_bytes = ops::linear_swiglu_workspace_capacity_bytes(
         profile.qtype, profile.gate_up_rows, profile.input_rows, policy, 1, maximum_tokens);
     WorkspaceArena workspace(std::max<std::size_t>(workspace_bytes, 256));

--- a/tests/ops/linear_swiglu/linear_swiglu_test_common.h
+++ b/tests/ops/linear_swiglu/linear_swiglu_test_common.h
@@ -12,6 +12,9 @@ enum class ActivationCompute : std::uint8_t {
     A16,
     A8,
     A4,
+    // Integer activations against groupwise-int weights, distinct from A8's FP8 path. Held to the
+    // same A8 activation allowance.
+    A8Int,
 };
 
 struct Profile {

--- a/tests/ops/linear_swiglu/test_q4_a8int.cpp
+++ b/tests/ops/linear_swiglu/test_q4_a8int.cpp
@@ -1,0 +1,30 @@
+#include "ops/linear_swiglu/linear_swiglu_test_common.h"
+
+#include <array>
+#include <exception>
+#include <iostream>
+
+int main() {
+    using namespace ninfer;
+    using namespace ninfer::test::linear_swiglu;
+
+    try {
+        // AllowA8Int is permissive: the integer route covers token counts that are positive
+        // multiples of 128 and the resolver falls back to A16 for the rest. These cases straddle
+        // that boundary deliberately -- 127/128/129 and 511/512/513 -- so both sides of the
+        // admission rule are exercised through the public Op, and every case is held to the same
+        // A8 activation allowance whichever route ran.
+        constexpr std::array<std::int32_t, 14> kTokenCases{
+            1, 2, 33, 127, 128, 129, 256, 257, 384, 511, 512, 513, 640, 1024,
+        };
+        const int failures = run_profile(
+            "LinearSwiGLU Q4_A8INT",
+            {QType::Q4G64_F16S, 34816, 5120, 17408, 1409U, ActivationCompute::A8Int},
+            kTokenCases);
+        std::cout << (failures == 0 ? "OK" : "FAIL") << " LinearSwiGLU Q4_A8INT correctness\n";
+        return failures == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "LinearSwiGLU Q4_A8INT test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/ops/linear_swiglu/test_q4a8_int.cpp
+++ b/tests/ops/linear_swiglu/test_q4a8_int.cpp
@@ -1,0 +1,263 @@
+// Correctness cover for the integer-activation prefill routes: the Q4G64 gate_up LinearSwiGLU and
+// the Q5G64 down LinearAdd.
+//
+// These routes are reached from the target variant rather than through ops::linear_swiglu, so the
+// shared run_profile harness cannot see them. They are verified here the same way: a deterministic
+// row-split payload from the quantized-weight fixture, an FP64 oracle over exactly decoded weights
+// and represented BF16 activations, and the activation-compute criterion for A8.
+//
+// The pass bound is upstream's own kA8QuantizationAllowance (0.04), the allowance the A8 activation
+// compute path is held to in tests/ops/linear/linear_test_common.cpp. The observed relative L2 is
+// printed on every case so drift inside that allowance is visible rather than silent -- it measures
+// about 0.009 on the real 27B weight, so a four-fold regression would still pass the gate but be
+// obvious in the output.
+
+#include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
+
+#include "ops/op_check.h"
+#include "ops/op_tester.h"
+#include "ops/quantized_weight.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace ninfer;
+using ninfer::test::ReductionCriterion;
+using ninfer::test::ReductionStats;
+using ninfer::test::compute_reduction_stats;
+using ninfer::test::verify_reduction;
+using ninfer::test::quantized_weight::PackedWeight;
+namespace qw = ninfer::test::quantized_weight;
+
+// One BF16 unit roundoff, and the A8 activation-quantisation allowance, both mirroring
+// tests/ops/linear/linear_test_common.cpp.
+constexpr double kBf16UnitRoundoff        = 1.0 / 256.0;
+constexpr double kA8QuantizationAllowance = 0.04;
+constexpr ReductionCriterion kA8Criterion{kA8QuantizationAllowance, kBf16UnitRoundoff,
+                                          1.5 * kA8QuantizationAllowance};
+
+// Hidden states are roughly Gaussian with a few fixed channels an order of magnitude larger. The
+// outlier channels are what per-token activation scaling gets wrong, so they belong in the fixture.
+std::vector<std::uint16_t> make_activation(std::int32_t rows, std::int32_t tokens,
+                                           std::uint32_t seed) {
+    std::vector<std::uint16_t> out(static_cast<std::size_t>(rows) * tokens);
+    for (std::int32_t t = 0; t < tokens; ++t) {
+        for (std::int32_t r = 0; r < rows; ++r) {
+            const std::uint64_t h = qw::detail::mix64(
+                (static_cast<std::uint64_t>(t) << 32) ^ static_cast<std::uint64_t>(r) ^ seed);
+            float v = static_cast<float>(static_cast<std::int32_t>(h & 0xffffu) - 32768) / 32768.0F;
+            if ((r % 431) == 7) { v *= 24.0F; } // fixed outlier channels
+            // BF16, round-to-nearest-even, so the oracle sees exactly what the kernel reads.
+            std::uint32_t bits;
+            std::memcpy(&bits, &v, sizeof(bits));
+            const std::uint32_t lsb = (bits >> 16) & 1u;
+            bits += 0x7fffu + lsb;
+            out[static_cast<std::size_t>(t) * rows + r] = static_cast<std::uint16_t>(bits >> 16);
+        }
+    }
+    return out;
+}
+
+float bf16_value(std::uint16_t bits) {
+    const std::uint32_t u = static_cast<std::uint32_t>(bits) << 16;
+    float f;
+    std::memcpy(&f, &u, sizeof(f));
+    return f;
+}
+
+std::vector<double> read_bf16(const test::GuardedDeviceBuffer& buffer, std::size_t elements) {
+    std::vector<std::uint16_t> host(elements);
+    buffer.copy_to_host(host.data(), elements * sizeof(std::uint16_t));
+    std::vector<double> out(elements);
+    for (std::size_t i = 0; i < elements; ++i) { out[i] = bf16_value(host[i]); }
+    return out;
+}
+
+// Sampled (row, token) pairs, so the FP64 oracle stays affordable at registered shapes.
+struct Samples {
+    std::vector<double> actual;
+    std::vector<double> reference;
+};
+
+int run_gate_up(std::int32_t tokens) {
+    constexpr std::int32_t kRows = 34816;
+    constexpr std::int32_t kCols = 5120;
+    constexpr std::int32_t kOut  = kRows / 2;
+
+    const PackedWeight host_weight =
+        qw::make_patterned_weight(QType::Q4G64_F16S, kRows, kCols, 4801U);
+    const std::vector<std::uint16_t> activation = make_activation(kCols, tokens, 91U);
+
+    test::GuardedDeviceBuffer device_weight(host_weight.payload.size());
+    device_weight.copy_from_host(host_weight.payload.data(), host_weight.payload.size());
+    const Weight weight = host_weight.device_weight(device_weight.data());
+
+    test::GuardedDeviceBuffer device_x(activation.size() * sizeof(std::uint16_t));
+    device_x.copy_from_host(activation.data(), activation.size() * sizeof(std::uint16_t));
+
+    const std::size_t out_elements = static_cast<std::size_t>(kOut) * tokens;
+    test::GuardedDeviceBuffer output(out_elements * sizeof(std::uint16_t));
+    output.fill(0xff);
+
+    WorkspaceArena workspace(
+        std::max<std::size_t>(ops::detail::q4a8_swiglu_workspace_capacity_bytes(tokens, tokens), 256));
+    Tensor x(device_x.data(), DType::BF16, {kCols, tokens});
+    Tensor destination(output.data(), DType::BF16, {kOut, tokens});
+    ops::detail::q4a8_swiglu_launch(x, weight, destination, workspace, nullptr);
+    test::cuda_check(cudaDeviceSynchronize(), "synchronize q4a8 swiglu");
+
+    const std::string label = "LinearSwiGLU Q4_A8INT T=" + std::to_string(tokens);
+    int failures            = 0;
+    failures += output.verify_guards(label);
+
+    const std::vector<double> got = read_bf16(output, out_elements);
+    Samples s;
+    std::vector<float> input(static_cast<std::size_t>(kCols));
+    for (int pick = 0; pick < 24; ++pick) {
+        const std::int32_t token = static_cast<std::int32_t>(
+            qw::detail::mix64(pick * 7919U + 3U) % static_cast<std::uint64_t>(tokens));
+        const std::int32_t row = static_cast<std::int32_t>(
+            qw::detail::mix64(pick * 104729U + 11U) % static_cast<std::uint64_t>(kOut));
+        for (std::int32_t k = 0; k < kCols; ++k) {
+            input[static_cast<std::size_t>(k)] =
+                bf16_value(activation[static_cast<std::size_t>(token) * kCols + k]);
+        }
+        const double gate = qw::dot_fp64(host_weight, row, input.data(), kCols);
+        const double up   = qw::dot_fp64(host_weight, kOut + row, input.data(), kCols);
+        s.reference.push_back(gate / (1.0 + std::exp(-gate)) * up);
+        s.actual.push_back(got[static_cast<std::size_t>(token) * kOut + row]);
+    }
+
+    const ReductionStats stats = compute_reduction_stats(
+        s.actual.data(), s.reference.data(), static_cast<std::int64_t>(s.actual.size()));
+    std::cout << "  " << label << " relative_l2=" << stats.relative_l2 << " (allowance "
+              << kA8QuantizationAllowance << ")\n";
+    failures += verify_reduction(label, s.actual, s.reference, kA8Criterion);
+    return failures;
+}
+
+int run_down(std::int32_t tokens) {
+    constexpr std::int32_t kRows = 5120;
+    constexpr std::int32_t kCols = 17408;
+
+    const PackedWeight host_weight =
+        qw::make_patterned_weight(QType::Q5G64_F16S, kRows, kCols, 5501U);
+    const std::vector<std::uint16_t> activation = make_activation(kCols, tokens, 77U);
+    const std::vector<std::uint16_t> residual0  = make_activation(kRows, tokens, 13U);
+
+    test::GuardedDeviceBuffer device_weight(host_weight.payload.size());
+    device_weight.copy_from_host(host_weight.payload.data(), host_weight.payload.size());
+    const Weight weight = host_weight.device_weight(device_weight.data());
+
+    test::GuardedDeviceBuffer device_x(activation.size() * sizeof(std::uint16_t));
+    device_x.copy_from_host(activation.data(), activation.size() * sizeof(std::uint16_t));
+
+    const std::size_t res_elements = static_cast<std::size_t>(kRows) * tokens;
+    test::GuardedDeviceBuffer device_residual(res_elements * sizeof(std::uint16_t));
+    device_residual.copy_from_host(residual0.data(), res_elements * sizeof(std::uint16_t));
+
+    WorkspaceArena workspace(
+        std::max<std::size_t>(ops::detail::q5a8_add_workspace_capacity_bytes(tokens, tokens), 256));
+    Tensor x(device_x.data(), DType::BF16, {kCols, tokens});
+    Tensor residual(device_residual.data(), DType::BF16, {kRows, tokens});
+    ops::detail::q5a8_add_launch(x, weight, residual, workspace, nullptr);
+    test::cuda_check(cudaDeviceSynchronize(), "synchronize q5a8 add");
+
+    const std::string label = "LinearAdd Q5_A8INT T=" + std::to_string(tokens);
+    int failures            = 0;
+    failures += device_residual.verify_guards(label);
+
+    const std::vector<double> got = read_bf16(device_residual, res_elements);
+    Samples s;
+    std::vector<float> input(static_cast<std::size_t>(kCols));
+    for (int pick = 0; pick < 24; ++pick) {
+        const std::int32_t token = static_cast<std::int32_t>(
+            qw::detail::mix64(pick * 6151U + 5U) % static_cast<std::uint64_t>(tokens));
+        const std::int32_t row = static_cast<std::int32_t>(
+            qw::detail::mix64(pick * 199933U + 17U) % static_cast<std::uint64_t>(kRows));
+        for (std::int32_t k = 0; k < kCols; ++k) {
+            input[static_cast<std::size_t>(k)] =
+                bf16_value(activation[static_cast<std::size_t>(token) * kCols + k]);
+        }
+        const double acc = qw::dot_fp64(host_weight, row, input.data(), kCols);
+        const double base =
+            bf16_value(residual0[static_cast<std::size_t>(token) * kRows + row]);
+        s.reference.push_back(base + acc);
+        s.actual.push_back(got[static_cast<std::size_t>(token) * kRows + row]);
+    }
+
+    const ReductionStats stats = compute_reduction_stats(
+        s.actual.data(), s.reference.data(), static_cast<std::int64_t>(s.actual.size()));
+    std::cout << "  " << label << " relative_l2=" << stats.relative_l2 << " (allowance "
+              << kA8QuantizationAllowance << ")\n";
+    failures += verify_reduction(label, s.actual, s.reference, kA8Criterion);
+    return failures;
+}
+
+// The routes must decline anything they do not cover, so the caller falls back to A16 rather than
+// producing a wrong answer. Decode and partial prefill chunks depend on this.
+int run_admission() {
+    int failures = 0;
+    const PackedWeight q4 =
+        qw::make_patterned_weight(QType::Q4G64_F16S, 34816, 5120, 1U);
+    const PackedWeight q5 =
+        qw::make_patterned_weight(QType::Q5G64_F16S, 5120, 17408, 2U);
+    const PackedWeight wrong_shape =
+        qw::make_patterned_weight(QType::Q4G64_F16S, 4096, 5120, 3U);
+
+    void* fake = reinterpret_cast<void*>(static_cast<std::uintptr_t>(4096));
+    struct Case {
+        const char* what;
+        bool got;
+        bool want;
+    };
+    const Case cases[] = {
+        {"q4 accepts 128 tokens", ops::detail::q4a8_swiglu_supported(q4.device_weight(fake), 128), true},
+        {"q4 accepts 1024 tokens", ops::detail::q4a8_swiglu_supported(q4.device_weight(fake), 1024), true},
+        {"q4 declines decode", ops::detail::q4a8_swiglu_supported(q4.device_weight(fake), 1), false},
+        {"q4 declines partial tile", ops::detail::q4a8_swiglu_supported(q4.device_weight(fake), 200), false},
+        {"q4 declines zero tokens", ops::detail::q4a8_swiglu_supported(q4.device_weight(fake), 0), false},
+        {"q4 declines a Q5 weight", ops::detail::q4a8_swiglu_supported(q5.device_weight(fake), 128), false},
+        {"q4 declines another shape", ops::detail::q4a8_swiglu_supported(wrong_shape.device_weight(fake), 128), false},
+        {"q4 declines a null payload", ops::detail::q4a8_swiglu_supported(q4.device_weight(nullptr), 128), false},
+        {"q5 accepts 128 tokens", ops::detail::q5a8_add_supported(q5.device_weight(fake), 128), true},
+        {"q5 declines decode", ops::detail::q5a8_add_supported(q5.device_weight(fake), 1), false},
+        {"q5 declines partial tile", ops::detail::q5a8_add_supported(q5.device_weight(fake), 129), false},
+        {"q5 declines a Q4 weight", ops::detail::q5a8_add_supported(q4.device_weight(fake), 128), false},
+        {"q5 declines a null high plane", ops::detail::q5a8_add_supported(q5.device_weight(nullptr), 128), false},
+    };
+    for (const Case& c : cases) {
+        if (c.got != c.want) {
+            std::cerr << "admission: " << c.what << " returned " << (c.got ? "true" : "false")
+                      << ", expected " << (c.want ? "true" : "false") << '\n';
+            ++failures;
+        }
+    }
+    return failures;
+}
+
+} // namespace
+
+int main() {
+    try {
+        int failures = run_admission();
+        for (const std::int32_t tokens : {128, 256, 512}) {
+            failures += run_gate_up(tokens);
+            failures += run_down(tokens);
+        }
+        std::cout << (failures == 0 ? "OK" : "FAIL")
+                  << " integer-activation prefill routes correctness\n";
+        return failures == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "integer-activation prefill route test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tools/tensor_core_rate_probe.cu
+++ b/tools/tensor_core_rate_probe.cu
@@ -1,0 +1,195 @@
+// Measures achieved tensor-core throughput on this GPU for the MMA shapes that matter to
+// ninfer-3090: the BF16 f32-accumulate path the kernels use today, the INT8 path the KV
+// attention kernel already uses, and the INT4 path nothing uses yet.
+//
+// Each warp runs CHAINS independent accumulator chains so MMA latency is hidden and the
+// measurement reflects issue throughput rather than dependency stalls. Operands stay in
+// registers; results are consumed at the end so nothing is optimised away.
+
+#include <cstdio>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#define CHECK(x)                                                                                   \
+    do {                                                                                           \
+        cudaError_t e = (x);                                                                       \
+        if (e != cudaSuccess) {                                                                    \
+            printf("CUDA error %s at line %d\n", cudaGetErrorString(e), __LINE__);                 \
+            return 1;                                                                              \
+        }                                                                                          \
+    } while (0)
+
+constexpr int kChains = 8;
+constexpr int kIters  = 8192;
+
+// ---- BF16, m16n8k16, f32 accumulate (what ninfer's mma_bf16 emits) ----
+__global__ void bf16_f32_probe(float* sink, unsigned seed) {
+    unsigned a0 = seed, a1 = seed ^ 0x5a5au, a2 = seed + 7u, a3 = seed * 3u;
+    unsigned b0 = seed ^ 0x1234u, b1 = seed + 11u;
+    float c[kChains][4];
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { c[i][0] = c[i][1] = c[i][2] = c[i][3] = 0.f; }
+
+    for (int it = 0; it < kIters; ++it) {
+#pragma unroll
+        for (int i = 0; i < kChains; ++i) {
+            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+                         "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                         : "+f"(c[i][0]), "+f"(c[i][1]), "+f"(c[i][2]), "+f"(c[i][3])
+                         : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+        }
+    }
+    float acc = 0.f;
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { acc += c[i][0] + c[i][1] + c[i][2] + c[i][3]; }
+    if (acc == 1234.5678f) { sink[0] = acc; }
+}
+
+// ---- FP16, m16n8k16, f16 accumulate (the un-halved GeForce rate, for reference) ----
+__global__ void f16_f16_probe(float* sink, unsigned seed) {
+    unsigned a0 = seed, a1 = seed ^ 0x5a5au, a2 = seed + 7u, a3 = seed * 3u;
+    unsigned b0 = seed ^ 0x1234u, b1 = seed + 11u;
+    unsigned c[kChains][2];
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { c[i][0] = c[i][1] = 0u; }
+
+    for (int it = 0; it < kIters; ++it) {
+#pragma unroll
+        for (int i = 0; i < kChains; ++i) {
+            asm volatile("mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+                         "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%0,%1};\n"
+                         : "+r"(c[i][0]), "+r"(c[i][1])
+                         : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+        }
+    }
+    unsigned acc = 0u;
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { acc += c[i][0] + c[i][1]; }
+    if (acc == 0xdeadbeefu) { sink[0] = (float)acc; }
+}
+
+// ---- INT8, m16n8k32, s32 accumulate (what mma_s8 emits) ----
+__global__ void s8_probe(float* sink, unsigned seed) {
+    unsigned a0 = seed, a1 = seed ^ 0x5a5au, a2 = seed + 7u, a3 = seed * 3u;
+    unsigned b0 = seed ^ 0x1234u, b1 = seed + 11u;
+    int c[kChains][4];
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { c[i][0] = c[i][1] = c[i][2] = c[i][3] = 0; }
+
+    for (int it = 0; it < kIters; ++it) {
+#pragma unroll
+        for (int i = 0; i < kChains; ++i) {
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                         "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                         : "+r"(c[i][0]), "+r"(c[i][1]), "+r"(c[i][2]), "+r"(c[i][3])
+                         : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+        }
+    }
+    int acc = 0;
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { acc += c[i][0] + c[i][1] + c[i][2] + c[i][3]; }
+    if (acc == 0x7fffffff) { sink[0] = (float)acc; }
+}
+
+// ---- INT8, m16n8k16 (the finer-k shape a group-16 scale would force) ----
+__global__ void s8_k16_probe(float* sink, unsigned seed) {
+    unsigned a0 = seed, a1 = seed ^ 0x5a5au;
+    unsigned b0 = seed ^ 0x1234u;
+    int c[kChains][4];
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { c[i][0] = c[i][1] = c[i][2] = c[i][3] = 0; }
+
+    for (int it = 0; it < kIters; ++it) {
+#pragma unroll
+        for (int i = 0; i < kChains; ++i) {
+            asm volatile("mma.sync.aligned.m16n8k16.row.col.s32.s8.s8.s32 "
+                         "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%0,%1,%2,%3};\n"
+                         : "+r"(c[i][0]), "+r"(c[i][1]), "+r"(c[i][2]), "+r"(c[i][3])
+                         : "r"(a0), "r"(a1), "r"(b0));
+        }
+    }
+    int acc = 0;
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { acc += c[i][0] + c[i][1] + c[i][2] + c[i][3]; }
+    if (acc == 0x7fffffff) { sink[0] = (float)acc; }
+}
+
+// ---- INT4, m16n8k64, s32 accumulate ----
+__global__ void s4_probe(float* sink, unsigned seed) {
+    unsigned a0 = seed, a1 = seed ^ 0x5a5au, a2 = seed + 7u, a3 = seed * 3u;
+    unsigned b0 = seed ^ 0x1234u, b1 = seed + 11u;
+    int c[kChains][4];
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { c[i][0] = c[i][1] = c[i][2] = c[i][3] = 0; }
+
+    for (int it = 0; it < kIters; ++it) {
+#pragma unroll
+        for (int i = 0; i < kChains; ++i) {
+            asm volatile("mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32 "
+                         "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                         : "+r"(c[i][0]), "+r"(c[i][1]), "+r"(c[i][2]), "+r"(c[i][3])
+                         : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+        }
+    }
+    int acc = 0;
+#pragma unroll
+    for (int i = 0; i < kChains; ++i) { acc += c[i][0] + c[i][1] + c[i][2] + c[i][3]; }
+    if (acc == 0x7fffffff) { sink[0] = (float)acc; }
+}
+
+template <class K> double run(K kernel, int blocks, int threads, float* sink, double ops_per_mma) {
+    // warmup
+    kernel<<<blocks, threads>>>(sink, 1u);
+    cudaDeviceSynchronize();
+
+    cudaEvent_t a, b;
+    cudaEventCreate(&a);
+    cudaEventCreate(&b);
+    cudaEventRecord(a);
+    const int reps = 5;
+    for (int r = 0; r < reps; ++r) { kernel<<<blocks, threads>>>(sink, 1u); }
+    cudaEventRecord(b);
+    cudaEventSynchronize(b);
+    float ms = 0.f;
+    cudaEventElapsedTime(&ms, a, b);
+    cudaEventDestroy(a);
+    cudaEventDestroy(b);
+
+    const double warps    = (double)blocks * (threads / 32);
+    const double mmas     = warps * (double)kIters * kChains * reps;
+    const double total_op = mmas * ops_per_mma;
+    return total_op / (ms / 1000.0) / 1e12; // TOPS or TFLOPS
+}
+
+int main() {
+    cudaDeviceProp p;
+    CHECK(cudaGetDeviceProperties(&p, 0));
+    printf("GPU: %s  sm_%d%d  %d SMs  %.0f MHz  mem %.0f MHz x %d-bit\n\n", p.name, p.major,
+           p.minor, p.multiProcessorCount, p.clockRate / 1000.0, p.memoryClockRate / 1000.0,
+           p.memoryBusWidth);
+
+    const int threads = 256;
+    const int blocks  = p.multiProcessorCount * 8;
+    float* sink       = nullptr;
+    CHECK(cudaMalloc(&sink, sizeof(float)));
+
+    // FLOPs/OPs per warp-level MMA = 2*M*N*K
+    const double f_k16 = 2.0 * 16 * 8 * 16;
+    const double f_k32 = 2.0 * 16 * 8 * 32;
+    const double f_k64 = 2.0 * 16 * 8 * 64;
+
+    const double bf16 = run(bf16_f32_probe, blocks, threads, sink, f_k16);
+    const double f16  = run(f16_f16_probe, blocks, threads, sink, f_k16);
+    const double s8   = run(s8_probe, blocks, threads, sink, f_k32);
+    const double s8k16 = run(s8_k16_probe, blocks, threads, sink, f_k16);
+    const double s4   = run(s4_probe, blocks, threads, sink, f_k64);
+
+    printf("  %-34s %8.1f TFLOPS   (1.00x baseline)\n", "BF16 m16n8k16, f32 accumulate", bf16);
+    printf("  %-34s %8.1f TFLOPS   %.2fx\n", "FP16 m16n8k16, f16 accumulate", f16, f16 / bf16);
+    printf("  %-34s %8.1f TOPS     %.2fx\n", "INT8 m16n8k32", s8, s8 / bf16);
+    printf("  %-34s %8.1f TOPS     %.2fx\n", "INT8 m16n8k16", s8k16, s8k16 / bf16);
+    printf("  %-34s %8.1f TOPS     %.2fx\n", "INT4 m16n8k64", s4, s4 / bf16);
+
+    cudaFree(sink);
+    return 0;
+}


### PR DESCRIPTION
# Integer-activation prefill route for the 27B MLP projections (sm_86)

Adds an activation-compute profile that feeds groupwise-int weights to Ampere's INT8 tensor
cores during prefill. On an RTX 3090 this is **1.22x prefill** on Qwen3.8-27B with perplexity
unchanged, and 1.30x when layered with the rk8v4 KV profile from #16.

Opt-in and default off, per PR_POLICY: set `NINFER_W4A8_PREFILL=1`. With the flag unset every
weight keeps `A16Only` and behaviour is bit-identical to master.

The observation behind it: on GA102, BF16 with FP32 accumulate is the slowest tensor path
available. Measured on the card (probe included in `tools/tensor_core_rate_probe.cu`):

| MMA shape | measured | vs BF16 |
|---|---:|---:|
| BF16 `m16n8k16`, f32 accumulate | 70.7 TFLOPS | 1.00x |
| FP16 `m16n8k16`, f16 accumulate | 145.0 TFLOPS | 2.05x |
| INT8 `m16n8k32` | 335.3 TOPS | **4.74x** |
| INT4 `m16n8k64` | 666.4 TOPS | 9.42x |

GeForce Ampere halves the FP32-accumulate float rate for product segmentation but leaves the
integer rates intact, so the A16 dequantizing GEMM the fork uses today is pinned to a quarter of
the integer ceiling. `q4_rowsplit_gemm_mma` already reaches 91% of that BF16 ceiling at the 27B
`mlp/gate_up` prefill shape, so it is not under-tuned -- it has run out of format.

## What changed

`LinearPolicy::AllowA8Int`, served by `ops::linear_swiglu` and `ops::linear_add`. Distinct from
`AllowA8`, which is the FP8 activation path against FP8 weights; this one quantises activations to
s8 with one scale per weight group and feeds groupwise-int weights to the integer MMA. The
resolver takes it where registered and falls back to A16 everywhere else.

Two registered profiles, both in the existing artifact -- no new model, no repack:

- `mlp/gate_up`, Q4G64_F16S `[34816,5120]`, through `linear_swiglu` with a fused SwiGLU
- `mlp/down`, Q5G64_F16S `[5120,17408]`, through `linear_add`

No storage-layout change was needed. For Q4 the `row-split-k128-v1` code plane is exactly
row-major `[n][k/2]` with two codes per byte and the scale plane exactly row-major `[n][k/64]`
FP16, so `Weight::qdata` and `Weight::scales` are indexed directly. Q5 adds an 8-byte-per-group
high plane for the fifth bit; a code decodes as `((low4 | hbit << 4) ^ 0x10) - 0x10` over
`[-16,15]`, still exact in int8, and the high plane is consumed during unpack so it never occupies
shared memory.

Two details worth calling out:

- **The fused SwiGLU is free.** `linear_swiglu` wants `SiLU(gate_up[i,t]) * gate_up[17408+i,t]`,
  and a gate row sits 136 blocks from its up row. Loading each block as 64 gate rows plus their 64
  up partners, ordered so one warp holds tile `gt` and tile `gt+4`, puts a row and its partner in
  the same thread's registers. The epilogue is `SiLU(acc[0]) * acc[1]` with no shared exchange.
- **Activation scales are per (token, group of 64), not per token.** A per-token absmax over 5120
  channels is set by whichever channel is largest and starves the rest. On the real layer-0 weight,
  per-token scaling measured 5-6x worse than per-group under injected outlier channels
  (1.29e-1 vs 2.02e-2 relative L2 at 64x outliers). It is also free where it is used, because the
  kernel already rescales once per group.

## Evidence

RTX 3090, driver 610.88, CUDA 12.8, `sm_86`. Qwen3.8-27B `groupwise-int`
(`qwen3_8_27b.ninfer`), `--kv-dtype int8 --mtp-draft-tokens 3 --lm-head-draft --max-ctx 8192
--prefill-chunk 1024`, C1, GPU otherwise idle. Measured on this branch, so the numbers reproduce
against master rather than against my fork.

Prefill throughput, `ninfer_bench -p 4362`, 5 reps after 1 warmup:

| `NINFER_W4A8_PREFILL` | prefill tok/s |
|---|---:|
| unset (default) | 1037.06 ± 2.29 |
| `1` | **1263.67 ± 17.94** |

**1.22x.** Decode is untouched: at T=1 the route declines and A16 runs.

Perplexity, `ninfer-perplexity --corpus ninfer-ppl-1m-v1 --quick --context 4096 --stride 2048
--kv-dtype int8`, 261,167 scored tokens:

| | overall ppl |
|---|---:|
| default | 4.343263 |
| route enabled | **4.342864** |

**-0.009%**, and all four domains improve slightly. The baseline reproduces the README's documented
4.343263 exactly, and both runs are deterministic, so the sign is real rather than noise. The likely
reason is that this route accumulates each 64-wide group in exact s32 and performs a single FP32
rescale per group, where the A16 route sums 64 BF16 products in FP32 and rounds at every add;
integer-exact accumulation buys back slightly more than 8-bit activations cost. Perplexity scoring
rate rose 468.7 -> 585.7 tok/s over the same run.

### Interaction with rk8v4 (#16)

Worth flagging because the two stack better than either alone. Measured with the rk8v4 KV profile
from #16 layered under this branch:

| KV profile | default | route enabled | speedup |
|---|---:|---:|---:|
| `int8` | 1037.06 | 1263.67 | 1.22x |
| `rk8v4` | 974.41 | 1262.21 | **1.30x** |

rk8v4 costs about **6.0% of prefill** at baseline, which is the trade #16 documents for 32% more
context. With this route enabled both KV profiles land within **0.12%** of each other, so that
prefill cost effectively disappears and rk8v4's context gain comes for free. The speedup therefore
reads larger on rk8v4 (1.30x) only because its baseline is lower.

I have not established the mechanism for that, and would rather not guess at one. It is an
observation from four measurements, not an explanation, and it is not load-bearing for this PR --
the 1.22x on stock `int8` stands on its own.

Also checked:

- **Vision.** `examples/cli/messages/image_natural.json` with `--vision`, answers both factual
  questions correctly (sign reads 24, sun on the right), verified against the image itself.
- **Concurrency.** `--max-concurrency 2`, two and then four simultaneous chat completions, all
  `finish=stop_token`, all answers correct, prefix reuse active. Batched decode never reaches the
  128-token tile, so this exercises the A16 fallback while sequences are batched.
- **VRAM.** Unchanged; the route allocates only transient activation planes from the existing Op
  workspace, and `work peak` stays at 152.6 MiB in both configurations.

## Accuracy contract

This adds activation-quantisation error the A16 route does not have, and is held to the same
allowance the FP8 A8 profile already gets. `tests/ops/linear_swiglu/linear_swiglu_test_common.cpp`
gives the A8 activation-compute profile a relative-L2 allowance of 8.0e-2 on the reasoning that
gate and up are each quantised independently before feeding the nonlinear product; that reasoning
applies verbatim here, so `ActivationCompute::A8Int` shares it. Measured on the real 27B weight
the route sits at ~9e-3, roughly an order of magnitude inside.

Determinism: bitwise-identical for a given token count and weight, since block-to-output mapping
is fixed and each output element is produced by exactly one thread. Output can differ from the
A16 route, and can differ across token counts because the admission rule selects a different
route -- the guarantee is per-configuration reproducibility, not parity with A16.

## Tests

- `tests/ops/linear_swiglu/test_q4_a8int.cpp` -- the shared `run_profile` harness through the
  public Op at T = 1, 2, 33, 127, 128, 129, 256, 257, 384, 511, 512, 513, 640, 1024, straddling
  the 128-token admission boundary on both sides.
- `tests/ops/linear_swiglu/test_q4a8_int.cpp` -- both routes against an FP64 oracle over exactly
  decoded weights and represented BF16 activations, using the `quantized_weight` fixture's real
  row-split payloads, with a deliberately harsh activation fixture (24x outliers on every 431st
  channel). Prints observed relative L2 per case so drift inside the allowance stays visible.
  Plus 13 admission cases asserting each route declines what it does not handle -- decode, partial
  tiles, zero tokens, wrong qtype, wrong shape, null payload, null high plane -- since the A16
  fallback depends on those refusals.

101/101 tests pass.

The shared harness earned its keep immediately: it asserts that a single-T workspace query equals
the execution high-water exactly, and caught the capacity function returning `max(A16, integer)`
regardless of which route would actually run. It failed at exactly T=128, 129, 384, 511 and 640
and passed elsewhere. The query is now route-aware.

## Scope and limitations

- Opt-in and default off. The Op-level registration of `AllowA8Int` is unconditional and fully
  covered by the harness; the flag only decides whether the 27B target asks for the policy. Once it
  has proven stable the default is worth reconsidering.
- 27B `groupwise-int` only. The 35B-A3B MLP is MoE through `sparse_moe` and is untouched.
- Prefill only. Decode is a GEMV at T=1, declines, and runs A16. This helps fresh long prompts;
  prefix reuse already elides most repeat prefill, so real-world benefit depends on cache hit rate.
- Prefill error propagates into the KV cache, so generation is affected through the context
  representation even though decode's own compute is not.
- `gdn_input_proj` is not covered. In prefill it goes through `gdn_input_proj_conv_snapshot` /
  `_conv_record`, which fuse the projection with the causal convolution and conv-state handling and
  whose split overloads take no policy -- materially more work than these two, not the same pattern.
- The `[5120,6144]` output projections were tried and **reverted**: carrying K at runtime to serve a
  second shape cost about 2% on the K=17408 path that was already working, and the extra shape
  bought nothing measurable (1236.80 ± 34.58 against 1262.21 ± 5.15). Worth revisiting only with K
  as a template parameter.
- Untested: other KV dtypes beyond int8/rk8v4, contexts beyond 8K, the full perplexity corpus,
  and Qwen3.6-27B (same variant, so it should behave identically -- but it has not been run).
