### PR TITLE
fix(qwen3.6): render zero-argument tool calls instead of throwing

### DIFF
--- a/src/targets/qwen3_6/impl/frontend/chat_template.cpp
+++ b/src/targets/qwen3_6/impl/frontend/chat_template.cpp
@@ -274,9 +274,9 @@ std::string parameter_text(const OrderedJson& value) {
     return tojson_text(value);
 }
 
-RenderedFragment render_tool_call(const ToolCall& call, bool allow_empty_arguments) {
+RenderedFragment render_tool_call(const ToolCall& call) {
     RenderBuilder rendered;
-    if (allow_empty_arguments && call.arguments_json.empty()) {
+    if (call.arguments_json.empty()) {
         rendered.append_template("<tool_call>\n<function=");
         rendered.append_literal(call.name);
         rendered.append_template(">\n</function>\n</tool_call>");
@@ -635,7 +635,7 @@ RenderedChat CompiledChatTemplate::render(const std::vector<ChatMessage>& messag
                 } else {
                     rendered.append_template("\n");
                 }
-                rendered.append(render_tool_call(message.tool_calls[call_index], effort_template));
+                rendered.append(render_tool_call(message.tool_calls[call_index]));
             }
         }
         rendered.append_template("<|im_end|>\n");

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -942,6 +942,19 @@ int test_reasoning_effort_chat_template() {
             .text.ends_with("<tool_call>\n<function=f>\n</function>\n"
                             "</tool_call><|im_end|>\n"),
         "empty tool arguments did not follow the reasoning-effort template");
+
+    // A zero-parameter tool call is legal on both templates: the official jinja renders the
+    // same empty <function> block either way, the reasoning-effort one via an explicit
+    // arguments != '' guard and the thinking-toggle one by iterating no arguments at all.
+    fi::ChatRenderOptions toggle_no_generation;
+    toggle_no_generation.add_generation_prompt = false;
+    failures += check(
+        thinking_toggle_template()
+            .render({chat_message(ninfer::ChatRole::User, "call"), empty_arguments},
+                    toggle_no_generation)
+            .text.ends_with("<tool_call>\n<function=f>\n</function>\n"
+                            "</tool_call><|im_end|>\n"),
+        "empty tool arguments were rejected by the thinking-toggle template");
     return failures;
 }
 


### PR DESCRIPTION
## Problem

A tool call whose `arguments` is an empty string makes the whole request fail with a 500 on any model whose artifact carries the **thinking-toggle** chat template — Qwen3.6-35B-A3B among them:

```json
{"error":{"code":null,"type":"internal_error","message":
 "[json.exception.parse_error.101] parse error at line 1, column 1: attempting to parse an empty input; ..."}}
```

### Reproducer

```bash
curl -s http://127.0.0.1:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model":"qwen3.6-35b-a3b","max_tokens":32,
  "messages":[
    {"role":"user","content":"what time is it"},
    {"role":"assistant","tool_calls":[{"id":"c1","type":"function",
      "function":{"name":"get_time","arguments":""}}]},
    {"role":"tool","tool_call_id":"c1","content":"12:04"}]}'
```

Any tool that takes no parameters produces this shape, so agentic use of a toggle-template model breaks on the first such call.

## Root cause

`render_tool_call()` only short-circuits empty arguments when `allow_empty_arguments` is set, and the single call site passes `effort_template` for it. On a toggle-template model that flag is false, so empty arguments reach `OrderedJson::parse("")`, which throws.

That distinction does not exist in the templates. Both render a zero-parameter call as the same empty `<function>` block:

| template | jinja guard | rendering |
|---|---|---|
| reasoning-effort | `{%- if tool_call.arguments is defined and tool_call.arguments != '' %}` | `<tool_call>\n<function=f>\n</function>\n</tool_call>` |
| thinking-toggle | `{%- if tool_call.arguments is defined %}`, then iterates no arguments | identical |

I extracted both `chat_template.jinja` resources from the `.ninfer` artifacts to confirm this rather than inferring it.

## Fix

The flag is removed; empty arguments are always a no-parameter call. Smallest change that makes the C++ renderer agree with the jinja it was derived from.

## Verification

- Regression test added for the toggle template in `tests/targets/qwen3_6/test_frontend.cpp`, alongside the existing reasoning-effort one.
- End to end on Qwen3.6-35B-A3B: the request above completes and the model consumes the tool result (`"I called the get_time function and received 12:04"`).

Host: RTX 3090 / Windows 11 / CUDA 12.8 / MSVC 19.44, Ninja Release build.

### Built and tested against this branch's base

Fresh Ninja Release build of `upstream/master` + this commit (`CMAKE_CUDA_ARCHITECTURES=86`, `BUILD_TESTING=ON`, `-DCMAKE_CUDA_FLAGS=-Xcompiler=/Zc:__cplusplus`), 442 targets, zero build failures. Suites run:

| suite | result |
|---|---|
| `ninfer_qwen3_6_frontend_test` | pass |
| `ninfer_serve_options_test` | pass |
| `ninfer_anthropic_schema_test` | pass |
| `ninfer_openai_schema_test` | pass |

(`ninfer_qwen3_6_frontend_test` prints a SKIP for the cases needing `NINFER_QWEN3_6_27B_HF_DIR`, an official HF export I do not have locally; the template-rendering cases this change touches all run.)
