### PR TITLE
fix(serve): collapse wider client effort vocabularies onto template rungs

### DIFF
--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -147,23 +147,24 @@ ResolvedPromptSemantics resolve_prompt_semantics(const GenerationRequest& reques
         return complete();
     }
 
+    // Clients carry a wider effort vocabulary than any Qwen3.6 template exposes: OpenAI and
+    // Claude Code send 'high', pi sends 'minimal' and 'max'. The template offers three rungs,
+    // so the outer values collapse onto the nearest one rather than failing the request --
+    // rejecting 'high' is what makes Claude Code unusable against a stock Qwen3.8 template
+    // (QwenLM/Qwen3.8#217). A template that lacks the resolved rung is still rejected below.
     switch (requested) {
+    case RequestedReasoningEffort::Minimal:
     case RequestedReasoningEffort::Low:
         result.reasoning_effort = ninfer::ReasoningEffort::Low;
         break;
     case RequestedReasoningEffort::Medium:
         result.reasoning_effort = ninfer::ReasoningEffort::Medium;
         break;
+    case RequestedReasoningEffort::High:
     case RequestedReasoningEffort::XHigh:
+    case RequestedReasoningEffort::Max:
         result.reasoning_effort = ninfer::ReasoningEffort::XHigh;
         break;
-    case RequestedReasoningEffort::Minimal:
-    case RequestedReasoningEffort::High:
-    case RequestedReasoningEffort::Max:
-        invalid_prompt_option("reasoning effort '" +
-                                  std::string(requested_reasoning_effort_name(requested)) +
-                                  "' is not supported by the loaded chat template",
-                              "reasoning_effort", "reasoning_effort_not_supported");
     case RequestedReasoningEffort::None:
         break;
     }

--- a/tests/test_serve_options.cpp
+++ b/tests/test_serve_options.cpp
@@ -271,6 +271,27 @@ int main() {
         check(explicit_effort.reasoning_effort == ninfer::ReasoningEffort::Low &&
                   explicit_effort.effective_reasoning_effort == ninfer::ReasoningEffort::Low,
               "explicit reasoning effort did not remain the effective effort");
+
+    // Client vocabularies wider than the template's three rungs collapse onto the nearest one:
+    // pi sends minimal/max, OpenAI and Claude Code send high. None of these may 400.
+    const auto collapses = [&](RequestedReasoningEffort wire) {
+        GenerationRequest aliased = request;
+        aliased.reasoning_effort  = wire;
+        return resolve_prompt_semantics(aliased, defaults, prompt_capabilities).reasoning_effort;
+    };
+    failures += check(collapses(RequestedReasoningEffort::Minimal) == ninfer::ReasoningEffort::Low,
+                      "'minimal' did not collapse onto the template's low rung");
+    failures += check(collapses(RequestedReasoningEffort::High) == ninfer::ReasoningEffort::XHigh,
+                      "'high' did not collapse onto the template's xhigh rung");
+    failures += check(collapses(RequestedReasoningEffort::Max) == ninfer::ReasoningEffort::XHigh,
+                      "'max' did not collapse onto the template's xhigh rung");
+    // Collapsing is not a licence to invent a rung the template lacks: medium is absent here.
+    bool unsupported_rung_rejected = false;
+    try {
+        (void)collapses(RequestedReasoningEffort::Medium);
+    } catch (const ApiException&) { unsupported_rung_rejected = true; }
+    failures += check(unsupported_rung_rejected,
+                      "an effort rung the template lacks survived the capability gate");
     request.reasoning_effort.reset();
     failures +=
         check(resolve_prompt_semantics(request, configured, prompt_capabilities).preserve_thinking,


### PR DESCRIPTION
## Problem

Clients carry a wider reasoning-effort vocabulary than the three rungs any Qwen3.6 chat template exposes, and these are rejected rather than mapped. Measured against a real Qwen3.8-27B over `/v1/responses`, **four of the seven levels a client can send return 400**:

| requested | before |
|---|---|
| `none` | accepted |
| `minimal` | **400** `reasoning_effort_not_supported` |
| `low` | accepted |
| `medium` | accepted |
| `high` | **400** `reasoning_effort_not_supported` |
| `xhigh` | accepted |
| `max` | **400** `reasoning_effort_not_supported` |

`high` is what OpenAI clients and Claude Code send by default, and `minimal`/`max` are in the pi coding agent's level set — so a stock client cannot talk to a model whose template *does* support effort. Same failure reported at [QwenLM/Qwen3.8#217](https://github.com/QwenLM/Qwen3.8/issues/217) against the stock template.

## Fix

`resolve_prompt_semantics()` collapses the outer values onto the nearest rung the template actually has:

- `minimal` → `Low`
- `high`, `max` → `XHigh`

`low` / `medium` / `xhigh` / `none` unchanged.

Collapsing happens **before** the capability gate, not instead of it: a rung the loaded template genuinely lacks is still rejected with `reasoning_effort_not_supported`. A thinking-toggle-template model (Qwen3.6-35B-A3B) therefore still rejects every effort value, which is correct — it has no effort steering at all.

### This is a contract change

A request that used to 400 now succeeds. Nothing that used to succeed changes behaviour, and nothing the template cannot do becomes accepted.

The alternative is to keep rejecting and make every client remap. That pushes the same three-line table into each client config and leaves stock Claude Code broken out of the box, so mapping server-side seemed the better default — but it is a judgement call and I am happy to be argued out of it, or to put it behind a flag.

## Verification

New coverage in `tests/test_serve_options.cpp` for all three collapses plus the negative case (a rung absent from the template still 400s).

Re-probed a live Qwen3.8-27B on `/v1/responses` after the change — all seven levels accepted, aliases grouping as intended:

| requested | thinking tokens |
|---|---|
| `none` | 0 |
| `minimal` | 231 |
| `low` | 222 |
| `medium` | 206 |
| `high` | 56 |
| `xhigh` | 53 |
| `max` | 66 |

The grouping is the signal (`minimal`≈`low`, `high`≈`xhigh`≈`max`); the prompt was trivial, so absolute magnitudes say nothing about effort quality.

Host: RTX 3090 / Windows 11 / CUDA 12.8 / MSVC 19.44, Ninja Release build.

### Built and tested against this branch's base

Fresh Ninja Release build of `upstream/master` + this commit (`CMAKE_CUDA_ARCHITECTURES=86`, `BUILD_TESTING=ON`, `-DCMAKE_CUDA_FLAGS=-Xcompiler=/Zc:__cplusplus`), 442 targets, zero build failures. Suites run:

| suite | result |
|---|---|
| `ninfer_qwen3_6_frontend_test` | pass |
| `ninfer_serve_options_test` | pass |
| `ninfer_anthropic_schema_test` | pass |
| `ninfer_openai_schema_test` | pass |

(`ninfer_qwen3_6_frontend_test` prints a SKIP for the cases needing `NINFER_QWEN3_6_27B_HF_DIR`, an official HF export I do not have locally; the template-rendering cases this change touches all run.)
