### PR TITLE
On-demand vision residency (overlay) on the v0.6.2 resource model: no resident Vision cost on 24 GiB cards

### DIFF
--- a/apps/cli/main.cpp
+++ b/apps/cli/main.cpp
@@ -282,6 +282,8 @@ int main(int argc, char** argv) {
         engine_options.kv_cache       = cli.kv_cache;
         engine_options.speculative    = cli.speculative;
         engine_options.enable_vision  = cli.enable_vision;
+        engine_options.vision_residency         = cli.vision_residency;
+        engine_options.vision_max_merged_tokens = cli.vision_max_merged_tokens;
         engine_options.use_cuda_graph = cli.use_cuda_graph;
         // One CLI invocation owns exactly one request, so retained cross-request context has no
         // consumer and must not reserve an extra Device StateImage or run terminal capture.

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -86,12 +86,15 @@ std::string usage_text(const char* argv0) {
            "       [--stop-token-id N]... [--stop <text>]... [--reasoning-stop <text>]...\n"
            "       [--raw-output] [--print-token-ids] [--no-thinking] [--thinking-budget N]\n"
            "       [--reasoning-effort low|medium|xhigh] [--vision]\n"
+           "       [--vision-residency resident|overlay] [--vision-max-merged N]\n"
            "       [--no-cuda-graph]\n"
            "\n"
            "Streams answer content to stdout and reasoning plus diagnostics to stderr.\n"
            "Structured message content accepts text, image/image_url, and video/video_url parts;\n"
            "media sources may be local paths, HTTP(S) URLs, or base64 data URIs.\n"
            "--vision enables image/video input and loads the fixed Vision GPU allocations.\n"
+           "--vision-residency overlay keeps the Vision tower in host memory and borrows device "
+           "memory per image; --vision-max-merged bounds one item's merged tokens (default 16384).\n"
            "--thinking-budget caps model-origin thinking tokens; inserted control tokens count "
            "toward --max-new.\n"
            "--kv-capacity auto leaves " +
@@ -153,6 +156,20 @@ Options parse_options(int argc, char** argv) {
             options.reasoning_effort = parse_reasoning_effort(value(arg));
         } else if (arg == "--vision") {
             options.enable_vision = true;
+        } else if (arg == "--vision-residency") {
+            const std::string_view mode = value(arg);
+            if (mode == "resident") {
+                options.vision_residency = VisionResidency::Resident;
+            } else if (mode == "overlay") {
+                options.vision_residency = VisionResidency::Overlay;
+            } else {
+                throw std::invalid_argument("--vision-residency must be resident or overlay");
+            }
+        } else if (arg == "--vision-max-merged") {
+            options.vision_max_merged_tokens = parse_u32(value(arg), "vision-max-merged");
+            if (options.vision_max_merged_tokens < 64 || options.vision_max_merged_tokens > 16384) {
+                throw std::invalid_argument("--vision-max-merged must be in [64, 16384]");
+            }
         } else if (arg == "--no-cuda-graph") {
             options.use_cuda_graph = false;
         } else if (arg == "--stop-token-id") {
@@ -216,6 +233,9 @@ Options parse_options(int argc, char** argv) {
     product::validate_speculative_cli_options(options.speculative);
     if (options.speculative.backend == SpeculativeBackend::DFlash && options.enable_vision) {
         throw std::invalid_argument("--spec dflash cannot be combined with --vision");
+    }
+    if (options.vision_residency == VisionResidency::Overlay && !options.enable_vision) {
+        throw std::invalid_argument("--vision-residency overlay requires --vision");
     }
     if (!options.enable_thinking && options.reasoning_effort) {
         throw std::invalid_argument("--reasoning-effort cannot be combined with --no-thinking");

--- a/apps/cli/options.h
+++ b/apps/cli/options.h
@@ -26,6 +26,8 @@ struct Options {
     KvCacheStorage kv_cache = KvCacheStorage::BFloat16;
     SpeculativeOptions speculative;
     bool enable_vision  = false;
+    VisionResidency vision_residency       = VisionResidency::Resident;
+    std::uint32_t vision_max_merged_tokens = 16384;
     bool use_cuda_graph = true;
 
     bool raw_output      = false;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,6 +193,8 @@ The table lists executable defaults. The examples above select FP8 KV and MTP3.
 | `--draft-tokens N` | MTP `1..5`; DFlash `1..15` | unset |
 | `--lm-head-draft` | optimized proposal head | off |
 | `--vision` | enable image/video input and load Vision GPU allocations | off |
+| `--vision-residency resident\|overlay` | `overlay` keeps the Vision tower host-pinned and borrows device memory per image from the evictable text weight tail (no resident Vision cost; needs CUDA VMM) | `resident` |
+| `--vision-max-merged N` | merged-token budget of one media item; larger media downscales at preprocessing | 16384 |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-thinking` | disable thinking in prompt rendering | thinking on |
 | `--thinking-budget N` | positive model-origin thinking-token cap; omitted means unlimited | unset |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -556,3 +556,64 @@ Each category contains three fixtures and five seeds per fixture, for 15 samples
 | Story | 15 | 126.1 ± 10.9 | 37.4% ± 5.8% | 2.12 ± 0.17 |
 | Translation | 15 | 192.3 ± 11.9 | 75.0% ± 6.5% | 3.25 ± 0.19 |
 | Structured | 15 | 219.8 ± 8.6 | 90.8% ± 5.1% | 3.72 ± 0.15 |
+
+### Vision residency on RTX 3090 (`groupwise-int`, sm_86)
+
+Dedicated RunPod RTX 3090 (24 GiB, driver 580.159, CUDA 13.1 build, nothing else on the GPU).
+Server flags common to every row: `--kv-capacity auto --max-concurrency 1 --prefill-chunk 1024
+--spec mtp --draft-tokens 3 --lm-head-draft`; the vision rows add `--vision --vision-max-merged
+12288` with `--vision-residency resident` or `overlay`. Maximum `--max-context` that boots,
+bisected to 8192 tokens:
+
+| `--kv-dtype` | no `--vision` (auto / explicit) | resident Vision (auto / explicit) | overlay Vision (auto / explicit) |
+|---|---|---|---|
+| `int8` | 147 456 / 180 224 | 122 880 / 159 744 | **147 456 / 180 224** |
+| `rk8v4` | 196 608 / 237 568 | 163 840 / 210 944 | **196 608 / 237 568** |
+| `bf16` | 73 728 / 92 160 | 65 536 / 81 920 | **73 728 / 92 160** |
+
+`auto` is `--kv-capacity auto` (keeps 1 GiB of automatic headroom); `explicit` is the largest `--kv-capacity N --max-context N` that boots, bisected to 2048 tokens, with a 1920×1080 image request completing at the overlay maximum.
+
+Overlay boots the no-vision capacity in every storage mode: the resident Vision cost
+(24 576 / 32 768 / 8 192 tokens) is gone. `free-after-weights` rises by 0.26 GiB (the tower is
+host-pinned) and the startup runtime reservation drops from 2.66 GiB to 2.23 GiB at 65 536 tokens.
+
+Greedy completions of a 1920×1080 gradient image (2074 merged tokens), of a 4000×3000 image
+downscaled by the budget to 11 767 merged tokens, and of their follow-up turns are byte-identical
+between residencies (`tools/smoke/overlay_ab.py`). The follow-up turn reuses the prefix and opens
+no window. At `--max-concurrency 2` two text requests complete alongside the image request.
+
+Text throughput without images is unchanged between residencies (7.7k-token prefill / 320-token
+decode, three runs each in one boot order): `int8` 852–862 vs 846–852 tok/s prefill and 53–62 vs
+55–60 tok/s decode, `rk8v4` 845–870 vs 857–875 tok/s prefill and 55–57 vs 57–58 tok/s decode.
+
+Per-image cost of a window (rk8v4, `--max-concurrency 1`): the 1920×1080 image reaches its first
+token in 3.55 s under overlay against 3.47 s resident (window 477 ms: 192 MiB evicted in 4 ms,
+restored in 11 ms, 282 MiB of tower streamed behind compute); the 4000×3000 image reaches it in
+22.8 s against 23.0 s (window 6.65 s, 784 MiB evicted in 10 ms, restored in 49 ms). Boot-to-boot
+prefill throughput on the rented card varies by about ±15 % (GPU clocks), so residencies are only
+compared within one run.
+
+#### Where a window borrows its memory
+
+An overlay window is funded from free KV pages when they cover it, and from the evict-ranked
+weight tail otherwise. The request log names the tier: `overlay=1xconc` for the KV-funded window,
+which leaves the text weights mapped so other lanes keep decoding, and `overlay=1xexcl` for the
+weight-tail window, which stops every lane until it closes.
+
+`tools/smoke/vision_stall_probe.py` streams one text completion and sends a 1920×1080 image
+request while it runs (`--max-concurrency 2`, `--prefill-chunk 256`, rk8v4). Inter-token gaps of
+the text stream:
+
+| window | KV capacity | gap p50 | gap p99 | gap max | window |
+|---|---|---|---|---|---|
+| `conc` (free KV pages) | 65 536 | 40 ms | 340 ms | 413 ms | 408 ms |
+| `excl` (weight tail) | 20 480 | 40 ms | 670 ms | 670 ms | 356 ms |
+
+The exclusive window adds its whole duration to the worst gap; the concurrent one does not, and
+what remains is the image prompt's own prefill chunks, which block decode in either case. A KV
+cache smaller than one window (the 20 480-token row) simply has no pages to lend, so every window
+there is exclusive and the engine behaves exactly as it did before this tier existed.
+
+The remapping itself is cheap on both paths: 192 MiB left the arena in 3.9–31 ms and came back in
+12–32 ms. The KV path pays more of it because it remaps 2 MiB granules where the weight path
+remaps 16 MiB chunks.

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -44,6 +44,33 @@ frozen by `--spec mtp|dflash` and `--draft-tokens`; omitting `--spec` loads neit
 `--lm-head-draft` additionally loads the optimized proposal head. DFlash is 35B-A3B text-only and
 cannot be combined with `--vision`. A later request cannot enable a capability omitted at startup.
 
+### Vision residency
+
+`--vision` keeps the Vision tower, its encode workspace and the item handoff resident for the
+process lifetime. `--vision-residency overlay` removes that cost on memory-tight cards: the tower
+lives in pinned host memory, the sequence plan reserves nothing for Vision, and each image is
+encoded inside a bounded window whose device memory is borrowed for the duration of the encode.
+
+A window is funded from free KV pages when they cover it. Those pages hold nothing, so nothing is
+copied, the text weights stay mapped, and the encode runs on its own stream while other lanes keep
+decoding: the lane that owns the image simply yields its prefill units until the encode completes.
+The pages are out of circulation while the loan is open, so the admission capacity shrinks with it
+and no request is ever admitted into memory that has been lent away.
+
+When free pages cannot cover the window, it falls back to the evict-ranked tail of the text weights
+(lm_head, token embedding, draft head, MTP head), restored from a pinned mirror before the prefill
+unit ends. That window is exclusive: the borrowed weights are unmapped, so nothing else runs until
+it closes. The fallback is always available, so a vision request never fails for lack of memory,
+and a KV cache smaller than one window simply uses it for every image.
+
+Either way the window streams the tower through two layer slots, lands the embeddings in pinned
+memory, and the prefill then uploads only each chunk's embedding columns. A follow-up turn over the
+same image reuses the prefix and opens no window. Embeddings are produced by the same kernels on the
+same bytes, so completions are identical between residencies. `--vision-max-merged N` bounds one
+item's merged tokens (media above it is downscaled at preprocessing) and sizes the window. The
+request log line reports `overlay=<windows>x<conc|excl|mixed> <ms> (evict <MiB> <ms>, restore <ms>,
+staged <MiB>)` and the JSON record carries `vision_overlay`, including `exclusive_windows`.
+
 ## Endpoints
 
 | Method and path | Behavior |
@@ -528,6 +555,8 @@ The table lists executable defaults. The startup example selects a long-context 
 | `--default-max-tokens N` | output limit when omitted by a request | `8192` |
 | `--default-thinking-budget N` | positive thinking cap inherited by thinking-enabled requests | unset |
 | `--vision` | enable media input and load Vision GPU allocations | off |
+| `--vision-residency resident\|overlay` | `overlay` keeps the Vision tower in pinned host memory and encodes each image inside a window borrowed from the evict-ranked text weight tail, so `--vision` no longer reserves device memory and `--kv-capacity auto` resolves the no-vision capacity; requires `--vision` and CUDA virtual memory management | `resident` |
+| `--vision-max-merged N` | merged-token budget of one media item, `[64, 16384]`; larger images and video frame pairs are downscaled at preprocessing instead of being rejected, and the overlay window is sized for it | 16384 |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-prefix-reuse` | disable compatible-prefix caching | prefix reuse on |
 | `--device-state-slots N` | extra Device checkpoint StateImages beyond the active-lane guarantee | `max-concurrency` |

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -102,6 +102,11 @@ struct ContextCostOptions {
     std::filesystem::path preset_path;
 };
 
+enum class VisionResidency : std::uint8_t {
+    Resident, // fixed Vision GPU allocations for the process lifetime
+    Overlay,  // tower host-pinned; each image borrows device memory inside a bounded window
+};
+
 struct EngineOptions {
     std::filesystem::path artifact_path;
     int device                         = 0;
@@ -118,6 +123,10 @@ struct EngineOptions {
     // Zero selects a bounded worker count from the detected host concurrency.
     std::uint32_t media_preprocess_threads = 0;
     bool enable_vision                     = false;
+    VisionResidency vision_residency       = VisionResidency::Resident;
+    // Largest merged-token count one media item may occupy; larger media is downscaled at
+    // preprocessing. Also bounds the overlay window.
+    std::uint32_t vision_max_merged_tokens = 16384;
     bool use_cuda_graph                    = true;
     ContextCacheOptions context_cache;
     ContextCostOptions context_cost;
@@ -457,6 +466,15 @@ struct GenerationTimings {
     double first_token_seconds = 0.0;
     double vision_seconds      = 0.0;
     double prefill_seconds     = 0.0;
+    // Overlay vision residency: per-request sums over the image windows.
+    std::uint32_t overlay_windows      = 0;
+    double overlay_window_seconds      = 0.0;
+    double overlay_evict_seconds       = 0.0;
+    double overlay_restore_seconds     = 0.0;
+    std::size_t overlay_evicted_bytes  = 0;
+    std::size_t overlay_staged_bytes   = 0;
+    // Windows that had to borrow the text weights, which stalls every other lane.
+    std::uint32_t overlay_exclusive_windows = 0;
     double decode_seconds      = 0.0;
     double total_seconds       = 0.0;
 };
@@ -598,6 +616,10 @@ struct VisionWorkspaceMemorySummary {
     std::size_t handoff_capacity_bytes    = 0;
     std::size_t handoff_active_bytes      = 0;
     std::size_t handoff_peak_bytes        = 0;
+    VisionResidency residency             = VisionResidency::Resident;
+    std::size_t window_capacity_bytes     = 0; // overlay: device bytes one window borrows
+    std::size_t pinned_weight_bytes       = 0; // overlay: host-pinned tower bytes
+    std::size_t mirror_bytes              = 0; // overlay: pinned mirror of the borrowable tail
 };
 
 struct MemorySummary {
@@ -775,6 +797,8 @@ struct LoadSummary {
     std::uint64_t artifact_bytes_read  = 0;
     std::uint64_t host_to_device_bytes = 0;
     std::uint64_t peak_staging_bytes   = 0;
+    std::uint64_t pinned_weight_bytes  = 0; // host-pinned weights (overlay vision tower)
+    std::uint64_t overlay_window_bytes = 0; // device bytes one overlay vision window borrows
     std::size_t tensor_count           = 0;
     std::size_t resource_count         = 0;
     ContextCostSummary context_cost;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(ninfer_core STATIC
   core/layout.cpp
   core/tensor.cpp
   core/decode_graph.cpp
+  core/evictable_kv_pool.cu
+  core/evictable_weight_pool.cu
   runtime/engine/admission_policy.cpp
   runtime/engine/context_cost.cpp
   runtime/engine/context_cost_defaults.cpp
@@ -37,7 +39,7 @@ add_library(ninfer_core STATIC
   runtime/engine/public_types.cpp)
 ninfer_internal_includes(ninfer_core)
 ninfer_cuda_archive(ninfer_core)
-target_link_libraries(ninfer_core PUBLIC ${NINFER_CUDART_TARGET} CUDA::nvtx3 Threads::Threads)
+target_link_libraries(ninfer_core PUBLIC ${NINFER_CUDART_TARGET} CUDA::nvtx3 Threads::Threads CUDA::cuda_driver)
 
 # Generic .ninfer framing, binding, and direct final materialization.
 add_library(ninfer_artifact STATIC

--- a/src/artifact/binder.cpp
+++ b/src/artifact/binder.cpp
@@ -83,7 +83,7 @@ PayloadSpan Binder::payload(ObjectHandle handle) const {
     return reader_.payload(descriptor(handle));
 }
 
-void Binder::materialize_on_device(ObjectHandle handle) {
+void Binder::materialize_on_device(ObjectHandle handle, std::uint32_t evict_rank) {
     const auto* tensor = std::get_if<TensorDescriptor>(&descriptor(handle));
     if (tensor == nullptr) {
         throw ArtifactError("resource cannot be materialized as a device tensor");
@@ -93,13 +93,40 @@ void Binder::materialize_on_device(ObjectHandle handle) {
                             std::string(tensor->name));
     }
     const std::uint64_t alignment = tensor_alignment(tensor->layout);
-    const std::uint64_t offset    = align_up(materialization_.device_capacity_bytes, alignment);
+    if (evict_rank != 0) {
+        // Evictable tensors receive their offsets in finish(): they are packed into the arena
+        // suffix so that higher ranks sit closer to the end.
+        evictable_.push_back(PendingEvictable{handle, tensor->bytes, alignment, evict_rank});
+        planned_[handle.index] = true;
+        return;
+    }
+    const std::uint64_t offset = align_up(materialization_.device_capacity_bytes, alignment);
     if (tensor->bytes > std::numeric_limits<std::uint64_t>::max() - offset) {
         throw ArtifactError("materialization plan size overflows u64");
     }
     materialization_.device_objects.push_back(
         DeviceMaterialization{handle, offset, tensor->bytes, alignment});
     materialization_.device_capacity_bytes = offset + tensor->bytes;
+    planned_[handle.index]                 = true;
+}
+
+void Binder::materialize_on_host_pinned(ObjectHandle handle) {
+    const auto* tensor = std::get_if<TensorDescriptor>(&descriptor(handle));
+    if (tensor == nullptr) {
+        throw ArtifactError("resource cannot be materialized as a pinned host tensor");
+    }
+    if (planned_[handle.index]) {
+        throw ArtifactError("artifact object has more than one materialization placement: " +
+                            std::string(tensor->name));
+    }
+    const std::uint64_t alignment = tensor_alignment(tensor->layout);
+    const std::uint64_t offset    = align_up(materialization_.pinned_capacity_bytes, alignment);
+    if (tensor->bytes > std::numeric_limits<std::uint64_t>::max() - offset) {
+        throw ArtifactError("materialization plan size overflows u64");
+    }
+    materialization_.pinned_objects.push_back(
+        PinnedMaterialization{handle, offset, tensor->bytes, alignment});
+    materialization_.pinned_capacity_bytes = offset + tensor->bytes;
     planned_[handle.index]                 = true;
 }
 
@@ -125,7 +152,7 @@ void Binder::validate_only(ObjectHandle handle) {
     planned_[handle.index] = true;
 }
 
-MaterializationPlan Binder::finish() {
+MaterializationPlan Binder::finish(std::uint64_t evictable_alignment) {
     const auto it = std::find(consumed_.begin(), consumed_.end(), false);
     if (it != consumed_.end()) {
         const auto index = static_cast<std::size_t>(it - consumed_.begin());
@@ -137,6 +164,34 @@ MaterializationPlan Binder::finish() {
         const auto index = static_cast<std::size_t>(unplanned - planned_.begin());
         throw ArtifactError("artifact object has no materialization placement: " +
                             std::string(object_name(reader_.objects()[index])));
+    }
+    if (!evictable_.empty()) {
+        if (evictable_alignment == 0) {
+            throw ArtifactError("evictable tail alignment must be nonzero");
+        }
+        // Ascending rank order packs the highest rank at the arena end, which the eviction pool
+        // unmaps first. Ties keep their registration order.
+        std::stable_sort(evictable_.begin(), evictable_.end(),
+                         [](const PendingEvictable& a, const PendingEvictable& b) {
+                             return a.rank < b.rank;
+                         });
+        const std::uint64_t tail_begin =
+            align_up(materialization_.device_capacity_bytes, evictable_alignment);
+        materialization_.evictable_tail_offset = tail_begin;
+        materialization_.device_capacity_bytes = tail_begin;
+        for (const PendingEvictable& pending : evictable_) {
+            const std::uint64_t offset =
+                align_up(materialization_.device_capacity_bytes, pending.alignment);
+            if (pending.bytes > std::numeric_limits<std::uint64_t>::max() - offset) {
+                throw ArtifactError("materialization plan size overflows u64");
+            }
+            materialization_.device_objects.push_back(
+                DeviceMaterialization{pending.handle, offset, pending.bytes, pending.alignment});
+            materialization_.device_capacity_bytes = offset + pending.bytes;
+        }
+        materialization_.evictable_tail_bytes =
+            materialization_.device_capacity_bytes - tail_begin;
+        evictable_.clear();
     }
     return std::move(materialization_);
 }

--- a/src/artifact/binder.h
+++ b/src/artifact/binder.h
@@ -13,6 +13,10 @@ namespace ninfer::artifact {
 enum class TensorPlacement : std::uint8_t {
     Device,
     ValidateOnly,
+    // Permanent pinned-host materialization: the tensor never receives device memory at load;
+    // its payload lands in one contiguous pinned block laid out with the same alignment rules as
+    // the device arena, so the block can be uploaded wholesale and addressed by offsets.
+    HostPinned,
 };
 
 struct ObjectHandle {
@@ -30,11 +34,25 @@ struct HostMaterialization {
     ObjectHandle object;
 };
 
+struct PinnedMaterialization {
+    ObjectHandle object;
+    std::uint64_t offset    = 0;
+    std::uint64_t bytes     = 0;
+    std::uint64_t alignment = 0;
+};
+
 struct MaterializationPlan {
     std::size_t object_count            = 0;
     std::uint64_t device_capacity_bytes = 0;
+    // Evict-ranked tensors form the arena suffix [evictable_tail_offset, device_capacity_bytes);
+    // the offset is aligned to the alignment passed to Binder::finish so an eviction pool can
+    // borrow whole chunks without touching resident objects. Both are zero without ranked tensors.
+    std::uint64_t evictable_tail_offset = 0;
+    std::uint64_t evictable_tail_bytes  = 0;
+    std::uint64_t pinned_capacity_bytes = 0;
     std::vector<DeviceMaterialization> device_objects;
     std::vector<HostMaterialization> host_objects;
+    std::vector<PinnedMaterialization> pinned_objects;
 };
 
 class Binder {
@@ -49,17 +67,30 @@ public:
 
     const ObjectDescriptor& descriptor(ObjectHandle handle) const;
     PayloadSpan payload(ObjectHandle handle) const;
-    void materialize_on_device(ObjectHandle handle);
+    // evict_rank 0 keeps the tensor resident for the process lifetime. A nonzero rank moves it
+    // into the arena's evictable tail; higher ranks land closer to the arena end and are evicted
+    // first.
+    void materialize_on_device(ObjectHandle handle, std::uint32_t evict_rank = 0);
+    void materialize_on_host_pinned(ObjectHandle handle);
     void retain_on_host(ObjectHandle handle);
     void validate_only(ObjectHandle handle);
-    MaterializationPlan finish();
+    // evictable_alignment aligns the evictable-tail begin (the eviction pool chunk size, or 1).
+    MaterializationPlan finish(std::uint64_t evictable_alignment = 1);
 
 private:
+    struct PendingEvictable {
+        ObjectHandle handle;
+        std::uint64_t bytes     = 0;
+        std::uint64_t alignment = 0;
+        std::uint32_t rank      = 0;
+    };
+
     ObjectHandle find_unconsumed(std::string_view name);
 
     const Reader& reader_;
     std::vector<bool> consumed_;
     std::vector<bool> planned_;
+    std::vector<PendingEvictable> evictable_;
     MaterializationPlan materialization_;
 };
 

--- a/src/artifact/materializer.cpp
+++ b/src/artifact/materializer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <stdexcept>
@@ -33,9 +34,18 @@ std::uint64_t align_up(std::uint64_t value, std::uint64_t alignment, const char*
 
 class Slot {
 public:
-    explicit Slot(std::size_t bytes) : buffer(bytes) {
+    // cudaMallocHost only guarantees sub-page alignment once other pinned allocations exist in
+    // the process; direct I/O requires 4096. Over-allocate and align the staging pointer.
+    explicit Slot(std::size_t bytes) : buffer(bytes + Reader::direct_io_alignment) {
+        const auto raw = reinterpret_cast<std::uintptr_t>(buffer.data());
+        const auto aligned =
+            (raw + Reader::direct_io_alignment - 1) / Reader::direct_io_alignment *
+            Reader::direct_io_alignment;
+        aligned_data = reinterpret_cast<std::byte*>(aligned);
         CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
     }
+
+    [[nodiscard]] std::byte* data() const noexcept { return aligned_data; }
 
     ~Slot() {
         if (pending) { (void)cudaEventSynchronize(event); }
@@ -50,8 +60,9 @@ public:
     }
 
     PinnedHostBuffer buffer;
-    cudaEvent_t event = nullptr;
-    bool pending      = false;
+    std::byte* aligned_data = nullptr;
+    cudaEvent_t event       = nullptr;
+    bool pending            = false;
 };
 
 struct CopyRange {
@@ -72,6 +83,32 @@ void* MaterializedArtifact::device_data(ObjectHandle handle) const {
         throw ArtifactError("object handle does not name a materialized tensor");
     }
     return objects_[handle.index].device;
+}
+
+void* MaterializedArtifact::storage_data(ObjectHandle handle) const {
+    if (handle.index >= objects_.size()) {
+        throw ArtifactError("object handle does not name a materialized tensor");
+    }
+    const ObjectStorage& storage = objects_[handle.index];
+    if (storage.device != nullptr) { return storage.device; }
+    if (storage.pinned != nullptr) { return storage.pinned; }
+    throw ArtifactError("object handle does not name a materialized tensor");
+}
+
+bool MaterializedArtifact::is_host_pinned(ObjectHandle handle) const noexcept {
+    return handle.index < objects_.size() && objects_[handle.index].pinned != nullptr;
+}
+
+std::size_t MaterializedArtifact::pinned_offset(ObjectHandle handle) const {
+    if (handle.index >= objects_.size() || objects_[handle.index].pinned == nullptr) {
+        throw ArtifactError("object handle does not name a pinned tensor");
+    }
+    return objects_[handle.index].pinned_offset;
+}
+
+std::span<const std::byte> MaterializedArtifact::pinned_block() const noexcept {
+    if (pinned_block_ == nullptr) { return {}; }
+    return {static_cast<const std::byte*>(pinned_block_->data()), pinned_block_->size()};
 }
 
 std::span<const std::byte> MaterializedArtifact::resource_bytes(ObjectHandle handle) const {
@@ -96,17 +133,47 @@ DeviceArena& MaterializedArtifact::device_arena() {
 }
 
 MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan& plan,
-                                 DeviceContext& device, LoadProgress* progress) {
+                                 DeviceContext& device, LoadProgress* progress,
+                                 std::unique_ptr<EvictableWeightPool> backing_pool) {
     MaterializedArtifact out;
     out.objects_.resize(plan.object_count);
     const std::uint64_t capacity = plan.device_capacity_bytes;
     if (capacity == 0 || capacity > static_cast<std::uint64_t>(SIZE_MAX)) {
         throw ArtifactError("artifact tensor backing size is invalid");
     }
-    out.device_arena_ = std::make_unique<DeviceArena>(static_cast<std::size_t>(capacity));
+    if (backing_pool != nullptr) {
+        const DeviceSpan backing = backing_pool->arena();
+        if (backing.bytes < capacity) {
+            throw ArtifactError("eviction pool arena is smaller than the materialization plan");
+        }
+        out.pool_         = std::move(backing_pool);
+        out.device_arena_ = std::make_unique<DeviceArena>(out.pool_->arena());
+    } else {
+        out.device_arena_ = std::make_unique<DeviceArena>(static_cast<std::size_t>(capacity));
+    }
     out.stats_.device_capacity_bytes = capacity;
-    out.stats_.tensor_count          = plan.device_objects.size();
+    out.stats_.tensor_count          = plan.device_objects.size() + plan.pinned_objects.size();
     out.stats_.resource_count        = plan.host_objects.size();
+
+    if (!plan.pinned_objects.empty()) {
+        out.pinned_block_ = std::make_unique<PinnedHostBuffer>(
+            static_cast<std::size_t>(plan.pinned_capacity_bytes));
+        auto* block = static_cast<std::byte*>(out.pinned_block_->data());
+        for (const PinnedMaterialization& placement : plan.pinned_objects) {
+            const PayloadSpan payload = reader.payload(reader.objects().at(placement.object.index));
+            if (payload.data.size() != placement.bytes ||
+                placement.offset > plan.pinned_capacity_bytes - placement.bytes) {
+                throw ArtifactError("pinned materialization does not match artifact payload");
+            }
+            std::memcpy(block + placement.offset, payload.data.data(), payload.data.size());
+            auto& storage         = out.objects_.at(placement.object.index);
+            storage.pinned        = block + placement.offset;
+            storage.pinned_offset = static_cast<std::size_t>(placement.offset);
+            out.stats_.pinned_weight_bytes += placement.bytes;
+            out.stats_.file_bytes = checked_add(out.stats_.file_bytes, placement.bytes,
+                                                "artifact read bytes overflow u64");
+        }
+    }
 
     for (const HostMaterialization& placement : plan.host_objects) {
         auto& resource            = out.objects_.at(placement.object.index).resource;
@@ -122,27 +189,29 @@ MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan
     std::uint64_t copied         = 0;
     std::uint64_t last_published = 0;
     std::uint64_t total          = 0;
+    // Objects sit at the offsets the plan assigned; the plan owns the whole arena.
+    auto* const arena_base     = static_cast<std::byte*>(out.device_arena_->base());
+    std::uint64_t previous_end = 0;
     for (const DeviceMaterialization& placement : plan.device_objects) {
         const PayloadSpan payload = reader.payload(reader.objects().at(placement.object.index));
-        DeviceSpan storage =
-            out.device_arena_->alloc_bytes(static_cast<std::size_t>(placement.bytes),
-                                           static_cast<std::size_t>(placement.alignment));
-        const auto actual_offset =
-            static_cast<std::uint64_t>(static_cast<std::byte*>(storage.data) -
-                                       static_cast<std::byte*>(out.device_arena_->base()));
-        if (actual_offset != placement.offset || payload.data.size() != placement.bytes) {
+        if (placement.offset < previous_end || placement.bytes > capacity ||
+            placement.offset > capacity - placement.bytes ||
+            payload.data.size() != placement.bytes) {
             throw ArtifactError("materialization plan does not match artifact payload");
         }
-        out.objects_.at(placement.object.index).device = storage.data;
+        previous_end         = placement.offset + placement.bytes;
+        std::byte* const dst = arena_base + placement.offset;
+        out.objects_.at(placement.object.index).device = dst;
         ranges.push_back(CopyRange{
             .source_begin = payload.absolute_offset,
             .source_end   = checked_add(payload.absolute_offset, placement.bytes,
                                         "artifact tensor source range overflows u64"),
-            .destination  = static_cast<std::byte*>(storage.data),
+            .destination  = dst,
         });
         total = checked_add(total, placement.bytes, "artifact tensor byte count overflows u64");
     }
     if (ranges.empty()) { throw ArtifactError("materialization plan has no device tensors"); }
+    (void)out.device_arena_->alloc_bytes(static_cast<std::size_t>(capacity), 1);
     std::sort(ranges.begin(), ranges.end(), [](const CopyRange& a, const CopyRange& b) {
         return a.source_begin < b.source_begin;
     });
@@ -195,8 +264,7 @@ MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan
             const std::size_t request     = static_cast<std::size_t>(std::min<std::uint64_t>(
                 slot_bytes,
                 align_up(remaining, alignment, "artifact direct I/O request overflows u64")));
-            auto destination =
-                std::span<std::byte>(static_cast<std::byte*>(slot.buffer.data()), request);
+            auto destination = std::span<std::byte>(slot.data(), request);
             const std::size_t bytes_read = reader.read_direct(source, destination);
             const std::uint64_t required = std::min<std::uint64_t>(request, remaining);
             if (bytes_read < required) {
@@ -220,8 +288,7 @@ MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan
                     CUDA_CHECK(cudaMemcpyAsync(
                         range.destination +
                             static_cast<std::size_t>(copy_begin - range.source_begin),
-                        static_cast<std::byte*>(slot.buffer.data()) +
-                            static_cast<std::size_t>(copy_begin - source),
+                        slot.data() + static_cast<std::size_t>(copy_begin - source),
                         amount, cudaMemcpyHostToDevice, device.transfer_stream));
                     copied =
                         checked_add(copied, amount, "artifact copied byte count overflows u64");

--- a/src/artifact/materializer.h
+++ b/src/artifact/materializer.h
@@ -3,6 +3,7 @@
 #include "artifact/binder.h"
 #include "core/arena.h"
 #include "core/device.h"
+#include "core/evictable_weight_pool.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -23,6 +24,7 @@ struct MaterializationStats {
     std::uint64_t h2d_bytes               = 0;
     std::uint64_t device_capacity_bytes   = 0;
     std::uint64_t retained_resource_bytes = 0;
+    std::uint64_t pinned_weight_bytes     = 0;
     std::uint64_t peak_staging_bytes      = 0;
     std::size_t tensor_count              = 0;
     std::size_t resource_count            = 0;
@@ -39,28 +41,44 @@ public:
     MaterializedArtifact& operator=(const MaterializedArtifact&)     = delete;
 
     void* device_data(ObjectHandle handle) const;
+    // Device pointer for device objects, pinned-host pointer for HostPinned objects.
+    void* storage_data(ObjectHandle handle) const;
+    [[nodiscard]] bool is_host_pinned(ObjectHandle handle) const noexcept;
+    std::size_t pinned_offset(ObjectHandle handle) const;
+    [[nodiscard]] std::span<const std::byte> pinned_block() const noexcept;
     std::span<const std::byte> resource_bytes(ObjectHandle handle) const;
     std::vector<std::byte> take_resource_bytes(ObjectHandle handle);
 
     const MaterializationStats& stats() const noexcept { return stats_; }
 
     DeviceArena& device_arena();
+    // Present only when the arena is backed by an eviction pool (overlay vision residency).
+    [[nodiscard]] EvictableWeightPool* eviction_pool() const noexcept { return pool_.get(); }
 
 private:
     friend MaterializedArtifact materialize(const Reader&, const MaterializationPlan&,
-                                            DeviceContext&, LoadProgress*);
+                                            DeviceContext&, LoadProgress*,
+                                            std::unique_ptr<EvictableWeightPool>);
 
     struct ObjectStorage {
-        void* device = nullptr;
+        void* device              = nullptr;
+        void* pinned              = nullptr;
+        std::size_t pinned_offset = 0;
         std::vector<std::byte> resource;
     };
 
+    std::unique_ptr<EvictableWeightPool> pool_;
     std::unique_ptr<DeviceArena> device_arena_;
+    std::unique_ptr<PinnedHostBuffer> pinned_block_;
     std::vector<ObjectStorage> objects_;
     MaterializationStats stats_;
 };
 
+// backing_pool, when provided, supplies the device arena storage and is owned by the returned
+// artifact. Its window mirror is not captured here; the caller captures it once the upload stream
+// is synchronized.
 MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan& plan,
-                                 DeviceContext& device, LoadProgress* progress = nullptr);
+                                 DeviceContext& device, LoadProgress* progress = nullptr,
+                                 std::unique_ptr<EvictableWeightPool> backing_pool = nullptr);
 
 } // namespace ninfer::artifact

--- a/src/artifact/typed_binding.cpp
+++ b/src/artifact/typed_binding.cpp
@@ -69,7 +69,7 @@ DType dtype_for(NumericFormat format) {
 Weight contiguous_weight(const MaterializedArtifact& materialized, ObjectHandle handle,
                          NumericFormat format, std::int32_t rows, std::int32_t columns) {
     Weight out{};
-    out.payload       = materialized.device_data(handle);
+    out.payload       = materialized.storage_data(handle);
     out.qdata         = out.payload;
     out.payload_bytes = static_cast<std::uint64_t>(rows) * columns * dtype_size(dtype_for(format));
     out.qtype         = qtype_for(format);
@@ -89,7 +89,7 @@ Weight row_split_weight(const MaterializedArtifact& materialized, ObjectHandle h
     const std::array<std::uint64_t, 2> shape = {static_cast<std::uint64_t>(rows),
                                                 static_cast<std::uint64_t>(columns)};
     const RowSplitGeometry geometry          = row_split_geometry(format, shape);
-    const auto* bytes = static_cast<const std::byte*>(materialized.device_data(handle));
+    const auto* bytes = static_cast<const std::byte*>(materialized.storage_data(handle));
 
     Weight out{};
     out.payload          = bytes;
@@ -118,7 +118,7 @@ Weight row_scale_weight(const MaterializedArtifact& materialized, ObjectHandle h
     const std::array<std::uint64_t, 2> shape = {static_cast<std::uint64_t>(rows),
                                                 static_cast<std::uint64_t>(columns)};
     const RowScaleGeometry geometry          = row_scale_geometry(format, shape);
-    const auto* bytes = static_cast<const std::byte*>(materialized.device_data(handle));
+    const auto* bytes = static_cast<const std::byte*>(materialized.storage_data(handle));
 
     Weight out{};
     out.payload         = bytes;
@@ -148,14 +148,21 @@ Weight row_scale_weight(const MaterializedArtifact& materialized, ObjectHandle h
 } // namespace
 
 ObjectHandle bind_tensor(Binder& binder, std::string_view name, NumericFormat format,
-                         std::initializer_list<std::uint64_t> shape, TensorPlacement placement) {
+                         std::initializer_list<std::uint64_t> shape, TensorPlacement placement,
+                         std::uint32_t evict_rank) {
     const ObjectHandle handle =
         binder.require_tensor(name, format, storage_layout_for(format),
                               std::span<const std::uint64_t>(shape.begin(), shape.size()));
-    if (placement == TensorPlacement::Device) {
-        binder.materialize_on_device(handle);
-    } else {
+    switch (placement) {
+    case TensorPlacement::Device:
+        binder.materialize_on_device(handle, evict_rank);
+        break;
+    case TensorPlacement::HostPinned:
+        binder.materialize_on_host_pinned(handle);
+        break;
+    case TensorPlacement::ValidateOnly:
         binder.validate_only(handle);
+        break;
     }
     return handle;
 }
@@ -174,7 +181,7 @@ ObjectHandle bind_raw_resource(Binder& binder, std::string_view name) {
 Tensor materialized_tensor(const MaterializedArtifact& materialized, ObjectHandle handle,
                            NumericFormat format,
                            std::initializer_list<std::int32_t> internal_shape) {
-    return Tensor(materialized.device_data(handle), dtype_for(format), internal_shape);
+    return Tensor(materialized.storage_data(handle), dtype_for(format), internal_shape);
 }
 
 Weight materialized_weight(const MaterializedArtifact& materialized, ObjectHandle handle,

--- a/src/artifact/typed_binding.h
+++ b/src/artifact/typed_binding.h
@@ -11,9 +11,11 @@ namespace ninfer::artifact {
 
 class MaterializedArtifact;
 
+// evict_rank applies to Device placement only: a nonzero rank moves the tensor into the arena's
+// evictable tail (higher rank == evicted earlier).
 [[nodiscard]] ObjectHandle bind_tensor(Binder& binder, std::string_view name, NumericFormat format,
                                        std::initializer_list<std::uint64_t> shape,
-                                       TensorPlacement placement);
+                                       TensorPlacement placement, std::uint32_t evict_rank = 0);
 
 [[nodiscard]] ObjectHandle bind_device_tensor(Binder& binder, std::string_view name,
                                               NumericFormat format,

--- a/src/core/device.cu
+++ b/src/core/device.cu
@@ -61,6 +61,7 @@ DeviceContext::DeviceContext(int device_id) : device(device_id) {
 
     cudaStream_t compute = nullptr;
     cudaStream_t load    = nullptr;
+    cudaStream_t vision  = nullptr;
     err                  = cudaStreamCreateWithFlags(&compute, cudaStreamNonBlocking);
     if (err != cudaSuccess) {
         throw std::runtime_error(
@@ -74,27 +75,39 @@ DeviceContext::DeviceContext(int device_id) : device(device_id) {
             cuda_error_message("cudaStreamCreateWithFlags(transfer_stream) failed", err));
     }
 
+    err = cudaStreamCreateWithFlags(&vision, cudaStreamNonBlocking);
+    if (err != cudaSuccess) {
+        destroy_stream(load);
+        destroy_stream(compute);
+        throw std::runtime_error(
+            cuda_error_message("cudaStreamCreateWithFlags(vision_stream) failed", err));
+    }
+
     stream          = compute;
     transfer_stream = load;
+    vision_stream   = vision;
 }
 
 DeviceContext::~DeviceContext() {
     if (stream != nullptr || transfer_stream != nullptr) { bind_to_current_thread_noexcept(); }
+    destroy_stream(vision_stream);
     destroy_stream(transfer_stream);
     destroy_stream(stream);
 }
 
 DeviceContext::DeviceContext(DeviceContext&& other) noexcept
     : device(other.device), stream(other.stream), transfer_stream(other.transfer_stream),
-      props(other.props) {
+      vision_stream(other.vision_stream), props(other.props) {
     other.stream          = nullptr;
     other.transfer_stream = nullptr;
+    other.vision_stream   = nullptr;
 }
 
 DeviceContext& DeviceContext::operator=(DeviceContext&& other) noexcept {
     if (this == &other) { return *this; }
 
     if (stream != nullptr || transfer_stream != nullptr) { bind_to_current_thread_noexcept(); }
+    destroy_stream(vision_stream);
     destroy_stream(transfer_stream);
     destroy_stream(stream);
 
@@ -102,9 +115,11 @@ DeviceContext& DeviceContext::operator=(DeviceContext&& other) noexcept {
     props           = other.props;
     stream          = other.stream;
     transfer_stream = other.transfer_stream;
+    vision_stream   = other.vision_stream;
 
     other.stream          = nullptr;
     other.transfer_stream = nullptr;
+    other.vision_stream   = nullptr;
     return *this;
 }
 

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -14,6 +14,9 @@ struct DeviceContext {
     int device                   = 0;
     cudaStream_t stream          = nullptr;
     cudaStream_t transfer_stream = nullptr;
+    // Carries a vision encode that runs beside the decode of other lanes. Empty unless a window
+    // borrows free KV memory, which is what makes the overlap safe.
+    cudaStream_t vision_stream = nullptr;
     cudaDeviceProp props{};
 
     explicit DeviceContext(int device_id = 0);

--- a/src/core/evictable_kv_pool.cu
+++ b/src/core/evictable_kv_pool.cu
@@ -1,0 +1,309 @@
+#include "core/evictable_kv_pool.h"
+
+#include <cuda.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace ninfer {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+void cu_check(CUresult result, const char* expr) {
+    if (result == CUDA_SUCCESS) { return; }
+    const char* name = nullptr;
+    (void)cuGetErrorName(result, &name);
+    throw std::runtime_error(std::string(expr) + " failed: " +
+                             (name != nullptr ? name : "unknown CUresult"));
+}
+
+#define NINFER_CU_CHECK(expr) ::ninfer::cu_check((expr), #expr)
+
+void ensure_driver_initialized() {
+    static std::once_flag once;
+    std::call_once(once, [] { NINFER_CU_CHECK(cuInit(0)); });
+}
+
+std::size_t align_up(std::size_t value, std::size_t alignment) {
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+double seconds_since(Clock::time_point start) {
+    return std::chrono::duration<double>(Clock::now() - start).count();
+}
+
+constexpr std::size_t kResidentPiece = 1024ULL * 1024ULL * 1024ULL;
+
+} // namespace
+
+struct EvictableKVPool::Impl {
+    DeviceContext& device;
+    Config config{};
+    std::size_t granularity       = 0;
+    std::size_t arena_reserved    = 0; // granularity-aligned home reservation
+    std::size_t window_reserved   = 0; // granularity-aligned overlay reservation
+    std::size_t lendable_granules = 0; // granules covering the KV payload prefix
+    CUdeviceptr home              = 0;
+    CUdeviceptr overlay           = 0;
+    // One handle per piece: the lendable prefix in granules, the remainder in large pieces.
+    // Offsets are arena offsets; the vectors are parallel and piece i of the prefix is granule i.
+    std::vector<CUmemGenericAllocationHandle> handles;
+    std::vector<std::size_t> offsets;
+    std::vector<std::size_t> sizes;
+    std::vector<std::size_t> lent; // granule indices currently mapped at the overlay range
+    bool poisoned = false;
+
+    explicit Impl(DeviceContext& context) : device(context) {}
+
+    void set_access(CUdeviceptr va, std::size_t bytes) {
+        CUmemAccessDesc access{};
+        access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        access.location.id   = device.device;
+        access.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+        NINFER_CU_CHECK(cuMemSetAccess(va, bytes, &access, 1));
+    }
+
+    void map_home(std::size_t piece) {
+        NINFER_CU_CHECK(cuMemMap(home + offsets[piece], sizes[piece], 0, handles[piece], 0));
+        set_access(home + offsets[piece], sizes[piece]);
+    }
+
+    void map_overlay(std::size_t piece, std::size_t rank) {
+        NINFER_CU_CHECK(cuMemMap(overlay + rank * granularity, sizes[piece], 0, handles[piece], 0));
+        set_access(overlay + rank * granularity, sizes[piece]);
+    }
+};
+
+bool EvictableKVPool::supported(const DeviceContext& device) {
+    ensure_driver_initialized();
+    CUdevice handle = 0;
+    if (cuDeviceGet(&handle, device.device) != CUDA_SUCCESS) { return false; }
+    int value = 0;
+    if (cuDeviceGetAttribute(&value, CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED,
+                             handle) != CUDA_SUCCESS) {
+        return false;
+    }
+    return value != 0;
+}
+
+std::size_t EvictableKVPool::device_granularity(const DeviceContext& device) {
+    if (!supported(device)) { return 0; }
+    CUmemAllocationProp prop{};
+    prop.type            = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type   = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id     = device.device;
+    std::size_t granularity = 0;
+    if (cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM) !=
+        CUDA_SUCCESS) {
+        return 0;
+    }
+    return granularity;
+}
+
+EvictableKVPool::EvictableKVPool(DeviceContext& device, const Config& config)
+    : impl_(std::make_unique<Impl>(device)) {
+    if (config.arena_bytes == 0) {
+        throw std::invalid_argument("evictable KV arena must not be empty");
+    }
+    if (config.lendable_prefix_bytes > config.arena_bytes) {
+        throw std::invalid_argument("evictable KV lendable prefix exceeds the arena");
+    }
+    if (config.window_capacity_bytes == 0) {
+        throw std::invalid_argument("evictable KV window capacity must be positive");
+    }
+    ensure_driver_initialized();
+    Impl& impl  = *impl_;
+    impl.config = config;
+
+    CUmemAllocationProp prop{};
+    prop.type          = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id   = device.device;
+    NINFER_CU_CHECK(cuMemGetAllocationGranularity(&impl.granularity, &prop,
+                                                  CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+    if (impl.granularity == 0) {
+        throw std::runtime_error("evictable KV pool read a zero VMM granularity");
+    }
+    if (kResidentPiece % impl.granularity != 0) {
+        throw std::runtime_error("evictable KV resident piece is not a granularity multiple");
+    }
+
+    impl.arena_reserved = align_up(config.arena_bytes, impl.granularity);
+    // Whole granules only: a granule that straddles the payload boundary stays resident.
+    impl.lendable_granules = config.lendable_prefix_bytes / impl.granularity;
+    impl.window_reserved   = align_up(config.window_capacity_bytes, impl.granularity);
+    if (impl.window_reserved > impl.lendable_granules * impl.granularity) {
+        throw std::invalid_argument("evictable KV window exceeds the lendable prefix");
+    }
+
+    NINFER_CU_CHECK(cuMemAddressReserve(&impl.home, impl.arena_reserved, impl.granularity, 0, 0));
+    NINFER_CU_CHECK(
+        cuMemAddressReserve(&impl.overlay, impl.window_reserved, impl.granularity, 0, 0));
+
+    std::size_t offset = 0;
+    for (std::size_t granule = 0; granule < impl.lendable_granules; ++granule) {
+        impl.offsets.push_back(offset);
+        impl.sizes.push_back(impl.granularity);
+        offset += impl.granularity;
+    }
+    while (offset < impl.arena_reserved) {
+        const std::size_t piece = std::min(kResidentPiece, impl.arena_reserved - offset);
+        impl.offsets.push_back(offset);
+        impl.sizes.push_back(piece);
+        offset += piece;
+    }
+
+    impl.handles.resize(impl.offsets.size());
+    for (std::size_t piece = 0; piece < impl.offsets.size(); ++piece) {
+        NINFER_CU_CHECK(cuMemCreate(&impl.handles[piece], impl.sizes[piece], &prop, 0));
+        impl.map_home(piece);
+    }
+}
+
+EvictableKVPool::~EvictableKVPool() {
+    if (impl_ == nullptr || impl_->home == 0) { return; }
+    Impl& impl = *impl_;
+    for (std::size_t rank = 0; rank < impl.lent.size(); ++rank) {
+        (void)cuMemUnmap(impl.overlay + rank * impl.granularity, impl.granularity);
+    }
+    for (std::size_t piece = 0; piece < impl.handles.size(); ++piece) {
+        const bool away = std::find(impl.lent.begin(), impl.lent.end(), piece) != impl.lent.end();
+        if (!away) { (void)cuMemUnmap(impl.home + impl.offsets[piece], impl.sizes[piece]); }
+        (void)cuMemRelease(impl.handles[piece]);
+    }
+    (void)cuMemAddressFree(impl.home, impl.arena_reserved);
+    (void)cuMemAddressFree(impl.overlay, impl.window_reserved);
+}
+
+DeviceSpan EvictableKVPool::arena() const noexcept {
+    return DeviceSpan{reinterpret_cast<void*>(impl_->home), impl_->config.arena_bytes};
+}
+
+std::size_t EvictableKVPool::granularity() const noexcept { return impl_->granularity; }
+
+std::size_t EvictableKVPool::lendable_granules() const noexcept { return impl_->lendable_granules; }
+
+std::size_t EvictableKVPool::window_capacity_bytes() const noexcept {
+    return impl_->window_reserved;
+}
+
+bool EvictableKVPool::lease_open() const noexcept { return !impl_->lent.empty(); }
+
+bool EvictableKVPool::poisoned() const noexcept { return impl_->poisoned; }
+
+std::size_t EvictableKVPool::granule_of(std::size_t offset) const {
+    if (offset >= impl_->config.arena_bytes) {
+        throw std::out_of_range("evictable KV offset is outside the arena");
+    }
+    return offset / impl_->granularity;
+}
+
+DeviceSpan EvictableKVPool::granule_bytes(std::size_t index) const {
+    if (index >= impl_->lendable_granules) {
+        throw std::out_of_range("evictable KV granule is outside the lendable prefix");
+    }
+    return DeviceSpan{reinterpret_cast<void*>(impl_->home + index * impl_->granularity),
+                      impl_->granularity};
+}
+
+EvictableKVPool::Transaction EvictableKVPool::lease(std::span<const std::size_t> granules,
+                                                    cudaStream_t stream) {
+    Impl& impl = *impl_;
+    if (impl.poisoned) {
+        throw std::runtime_error("evictable KV pool is poisoned by a failed return");
+    }
+    if (!impl.lent.empty()) { throw std::logic_error("evictable KV lease is already open"); }
+    if (granules.empty()) { throw std::invalid_argument("evictable KV lease needs a granule"); }
+    if (granules.size() * impl.granularity > impl.window_reserved) {
+        throw std::invalid_argument("evictable KV lease exceeds the window capacity: " +
+                                    std::to_string(granules.size()) + " granules");
+    }
+    for (std::size_t rank = 0; rank < granules.size(); ++rank) {
+        if (granules[rank] >= impl.lendable_granules) {
+            throw std::invalid_argument("evictable KV lease names a resident granule");
+        }
+        if (rank != 0 && granules[rank] <= granules[rank - 1]) {
+            throw std::invalid_argument("evictable KV lease granules must strictly increase");
+        }
+    }
+    // No stream is quiesced here, and that is the point of this pool: a lent granule lies
+    // entirely inside free KV pages, so no in-flight kernel reads or writes it and other lanes
+    // keep running while the window is open.
+    const auto start = Clock::now();
+    impl.lent.reserve(granules.size());
+    for (std::size_t rank = 0; rank < granules.size(); ++rank) {
+        const std::size_t piece = granules[rank];
+        NINFER_CU_CHECK(cuMemUnmap(impl.home + impl.offsets[piece], impl.sizes[piece]));
+        impl.map_overlay(piece, rank);
+        impl.lent.push_back(piece);
+    }
+    return Transaction(*this,
+                       DeviceSpan{reinterpret_cast<void*>(impl.overlay),
+                                  granules.size() * impl.granularity},
+                       stream, seconds_since(start));
+}
+
+void EvictableKVPool::give_back(Transaction& transaction) noexcept {
+    Impl& impl = *impl_;
+    if (impl.lent.empty()) { return; }
+    const auto start = Clock::now();
+    try {
+        for (std::size_t rank = 0; rank < impl.lent.size(); ++rank) {
+            NINFER_CU_CHECK(cuMemUnmap(impl.overlay + rank * impl.granularity, impl.granularity));
+            impl.map_home(impl.lent[rank]);
+        }
+    } catch (const std::exception& error) {
+        impl.poisoned = true;
+        std::fprintf(stderr,
+                     "ninfer: evictable KV pool return failed (%s); the KV cache is no longer "
+                     "trustworthy\n",
+                     error.what());
+    } catch (...) {
+        impl.poisoned = true;
+        std::fprintf(stderr, "ninfer: evictable KV pool return failed; the KV cache is no longer "
+                             "trustworthy\n");
+    }
+    impl.lent.clear();
+    transaction.stats_.return_seconds = seconds_since(start);
+}
+
+EvictableKVPool::Transaction::Transaction(EvictableKVPool& pool, DeviceSpan leased,
+                                          cudaStream_t stream, double lease_seconds) noexcept
+    : pool_(&pool), leased_(leased), stream_(stream) {
+    stats_.lease_seconds = lease_seconds;
+    stats_.mapped_bytes  = leased.bytes;
+}
+
+EvictableKVPool::Transaction::~Transaction() { close(); }
+
+EvictableKVPool::Transaction::Transaction(Transaction&& other) noexcept
+    : pool_(other.pool_), leased_(other.leased_), stream_(other.stream_), stats_(other.stats_) {
+    other.pool_ = nullptr;
+}
+
+EvictableKVPool::Transaction&
+EvictableKVPool::Transaction::operator=(Transaction&& other) noexcept {
+    if (this != &other) {
+        close();
+        pool_       = other.pool_;
+        leased_     = other.leased_;
+        stream_     = other.stream_;
+        stats_      = other.stats_;
+        other.pool_ = nullptr;
+    }
+    return *this;
+}
+
+void EvictableKVPool::Transaction::close() noexcept {
+    if (pool_ == nullptr) { return; }
+    pool_->give_back(*this);
+    pool_ = nullptr;
+}
+
+} // namespace ninfer

--- a/src/core/evictable_kv_pool.h
+++ b/src/core/evictable_kv_pool.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "core/arena.h"
+#include "core/device.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace ninfer {
+
+// VMM-backed persistent arena whose KV payload prefix can lend individual granules for a bounded
+// window. Every store binds at the offsets it uses today, so plane pointers, block tables and the
+// captured decode graphs stay valid: the home mapping never moves and only granules that lie
+// entirely inside free KV pages are ever unmapped.
+//
+// Unlike the weight pool there is no host mirror. A lent granule holds free pages only, and no
+// page is read before the append kernel writes it, so closing a lease remaps home and copies
+// nothing.
+//
+// Neither lease() nor close() quiesces a stream: the caller guarantees that every lent granule
+// lies entirely inside free KV pages, so no in-flight work addresses it and decode continues on
+// the main stream while a window is open.
+class EvictableKVPool {
+public:
+    struct Config {
+        std::size_t arena_bytes           = 0; // persistent arena capacity
+        std::size_t lendable_prefix_bytes = 0; // KV payload prefix eligible for lending
+        std::size_t window_capacity_bytes = 0; // largest extent one lease may hand out
+    };
+
+    struct LeaseStats {
+        double lease_seconds     = 0.0;
+        double return_seconds    = 0.0;
+        std::size_t mapped_bytes = 0;
+    };
+
+    class Transaction {
+    public:
+        Transaction() noexcept = default;
+        ~Transaction();
+
+        Transaction(const Transaction&)            = delete;
+        Transaction& operator=(const Transaction&) = delete;
+        Transaction(Transaction&& other) noexcept;
+        Transaction& operator=(Transaction&& other) noexcept;
+
+        [[nodiscard]] bool open() const noexcept { return pool_ != nullptr; }
+        [[nodiscard]] DeviceSpan leased() const noexcept { return leased_; }
+        [[nodiscard]] const LeaseStats& stats() const noexcept { return stats_; }
+
+        // Remaps the lent granules home. Never throws: a failure poisons the pool, which the
+        // owner must treat as fatal for the KV cache.
+        void close() noexcept;
+
+    private:
+        friend class EvictableKVPool;
+
+        Transaction(EvictableKVPool& pool, DeviceSpan leased, cudaStream_t stream,
+                    double lease_seconds) noexcept;
+
+        EvictableKVPool* pool_ = nullptr;
+        DeviceSpan leased_{};
+        cudaStream_t stream_ = nullptr;
+        LeaseStats stats_{};
+    };
+
+    [[nodiscard]] static bool supported(const DeviceContext& device);
+    // VMM allocation granularity of the device, or zero when virtual memory management is
+    // unavailable. Lets a caller decide whether a window fits the lendable prefix before it
+    // commits to building a pool.
+    [[nodiscard]] static std::size_t device_granularity(const DeviceContext& device);
+
+    EvictableKVPool(DeviceContext& device, const Config& config);
+    ~EvictableKVPool();
+
+    EvictableKVPool(const EvictableKVPool&)            = delete;
+    EvictableKVPool& operator=(const EvictableKVPool&) = delete;
+
+    // Stable home mapping backing the persistent arena for the process lifetime.
+    [[nodiscard]] DeviceSpan arena() const noexcept;
+    [[nodiscard]] std::size_t granularity() const noexcept;
+    // Granules covering the lendable prefix; indices beyond this are permanently resident.
+    [[nodiscard]] std::size_t lendable_granules() const noexcept;
+    [[nodiscard]] std::size_t window_capacity_bytes() const noexcept;
+    [[nodiscard]] bool lease_open() const noexcept;
+    [[nodiscard]] bool poisoned() const noexcept;
+
+    // Granule containing an arena offset, and the arena range one granule covers.
+    [[nodiscard]] std::size_t granule_of(std::size_t offset) const;
+    [[nodiscard]] DeviceSpan granule_bytes(std::size_t index) const;
+
+    // Lends the given granules, mapped consecutively at the overlay range in the order supplied.
+    // Indices must be strictly increasing and inside the lendable prefix.
+    [[nodiscard]] Transaction lease(std::span<const std::size_t> granules, cudaStream_t stream);
+
+private:
+    struct Impl;
+
+    void give_back(Transaction& transaction) noexcept;
+
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace ninfer

--- a/src/core/evictable_weight_pool.cu
+++ b/src/core/evictable_weight_pool.cu
@@ -1,0 +1,320 @@
+#include "core/evictable_weight_pool.h"
+
+#include <cuda.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace ninfer {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+void cu_check(CUresult result, const char* expr) {
+    if (result == CUDA_SUCCESS) { return; }
+    const char* name = nullptr;
+    (void)cuGetErrorName(result, &name);
+    throw std::runtime_error(std::string(expr) + " failed: " +
+                             (name != nullptr ? name : "unknown CUresult"));
+}
+
+#define NINFER_CU_CHECK(expr) ::ninfer::cu_check((expr), #expr)
+
+void ensure_driver_initialized() {
+    static std::once_flag once;
+    std::call_once(once, [] { NINFER_CU_CHECK(cuInit(0)); });
+}
+
+std::size_t align_up(std::size_t value, std::size_t alignment) {
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+double seconds_since(Clock::time_point start) {
+    return std::chrono::duration<double>(Clock::now() - start).count();
+}
+
+} // namespace
+
+struct EvictableWeightPool::Impl {
+    DeviceContext& device;
+    Config config{};
+    std::size_t granularity     = 0;
+    std::size_t arena_reserved  = 0; // chunk-aligned home reservation
+    std::size_t window_reserved = 0; // chunk-aligned overlay reservation
+    std::size_t tail_begin      = 0; // arena offset of the first evictable chunk
+    std::size_t mirror_begin    = 0; // arena offset of the first mirrored byte
+    std::size_t mirror_extent   = 0; // mirrored bytes: [mirror_begin, arena_bytes)
+    CUdeviceptr home            = 0;
+    CUdeviceptr overlay         = 0;
+    // One handle per region piece: [0, tail_begin) in large pieces, the tail in kChunkBytes
+    // chunks. Offsets are arena offsets; the vectors are parallel.
+    std::vector<CUmemGenericAllocationHandle> handles;
+    std::vector<std::size_t> offsets;
+    std::vector<std::size_t> sizes;
+    std::size_t evicted_pieces = 0; // pieces currently mapped at the overlay range
+    std::unique_ptr<PinnedHostBuffer> mirror;
+    bool mirror_captured = false;
+    bool poisoned        = false;
+
+    explicit Impl(DeviceContext& context) : device(context) {}
+
+    void set_access(CUdeviceptr va, std::size_t bytes) {
+        CUmemAccessDesc access{};
+        access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        access.location.id   = device.device;
+        access.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+        NINFER_CU_CHECK(cuMemSetAccess(va, bytes, &access, 1));
+    }
+
+    void map_home(std::size_t piece) {
+        NINFER_CU_CHECK(cuMemMap(home + offsets[piece], sizes[piece], 0, handles[piece], 0));
+        set_access(home + offsets[piece], sizes[piece]);
+    }
+
+    void map_overlay(std::size_t piece, std::size_t rank) {
+        NINFER_CU_CHECK(
+            cuMemMap(overlay + rank * kChunkBytes, sizes[piece], 0, handles[piece], 0));
+        set_access(overlay + rank * kChunkBytes, sizes[piece]);
+    }
+};
+
+bool EvictableWeightPool::supported(const DeviceContext& device) {
+    ensure_driver_initialized();
+    CUdevice handle = 0;
+    if (cuDeviceGet(&handle, device.device) != CUDA_SUCCESS) { return false; }
+    int value = 0;
+    if (cuDeviceGetAttribute(&value, CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED,
+                             handle) != CUDA_SUCCESS) {
+        return false;
+    }
+    return value != 0;
+}
+
+EvictableWeightPool::EvictableWeightPool(DeviceContext& device, const Config& config)
+    : impl_(std::make_unique<Impl>(device)) {
+    if (config.arena_bytes == 0) {
+        throw std::invalid_argument("evictable pool arena must not be empty");
+    }
+    if (config.evictable_tail_bytes == 0 || config.evictable_tail_bytes > config.arena_bytes) {
+        throw std::invalid_argument("evictable pool tail must be a nonempty arena suffix");
+    }
+    if (config.window_capacity_bytes == 0) {
+        throw std::invalid_argument("evictable pool window capacity must be positive");
+    }
+    ensure_driver_initialized();
+    Impl& impl  = *impl_;
+    impl.config = config;
+
+    CUmemAllocationProp prop{};
+    prop.type          = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id   = device.device;
+    NINFER_CU_CHECK(cuMemGetAllocationGranularity(&impl.granularity, &prop,
+                                                  CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+    if (kChunkBytes % impl.granularity != 0) {
+        throw std::runtime_error("evictable pool chunk is not a multiple of the VMM granularity");
+    }
+
+    impl.arena_reserved = align_up(config.arena_bytes, kChunkBytes);
+    // Chunk-align into the evictable suffix so no chunk ever covers a resident object.
+    impl.tail_begin      = align_up(config.arena_bytes - config.evictable_tail_bytes, kChunkBytes);
+    impl.window_reserved = align_up(config.window_capacity_bytes, kChunkBytes);
+    if (impl.window_reserved > impl.arena_reserved - impl.tail_begin) {
+        throw std::invalid_argument("evictable pool window exceeds the evictable tail");
+    }
+    impl.mirror_begin  = impl.arena_reserved - impl.window_reserved;
+    impl.mirror_extent = config.arena_bytes > impl.mirror_begin
+                             ? config.arena_bytes - impl.mirror_begin
+                             : 0;
+
+    NINFER_CU_CHECK(cuMemAddressReserve(&impl.home, impl.arena_reserved, kChunkBytes, 0, 0));
+    NINFER_CU_CHECK(cuMemAddressReserve(&impl.overlay, impl.window_reserved, kChunkBytes, 0, 0));
+
+    constexpr std::size_t kPrefixPiece = 1024ULL * 1024ULL * 1024ULL;
+    std::size_t offset                 = 0;
+    while (offset < impl.tail_begin) {
+        const std::size_t piece = std::min(kPrefixPiece, impl.tail_begin - offset);
+        impl.offsets.push_back(offset);
+        impl.sizes.push_back(piece);
+        offset += piece;
+    }
+    while (offset < impl.arena_reserved) {
+        impl.offsets.push_back(offset);
+        impl.sizes.push_back(kChunkBytes);
+        offset += kChunkBytes;
+    }
+
+    impl.handles.resize(impl.offsets.size());
+    for (std::size_t piece = 0; piece < impl.offsets.size(); ++piece) {
+        NINFER_CU_CHECK(cuMemCreate(&impl.handles[piece], impl.sizes[piece], &prop, 0));
+        impl.map_home(piece);
+    }
+}
+
+EvictableWeightPool::~EvictableWeightPool() {
+    if (impl_ == nullptr || impl_->home == 0) { return; }
+    Impl& impl               = *impl_;
+    const std::size_t pieces = impl.handles.size();
+    for (std::size_t piece = 0; piece < pieces; ++piece) {
+        const bool away = impl.evicted_pieces != 0 && piece >= pieces - impl.evicted_pieces;
+        if (away) {
+            const std::size_t rank = piece - (pieces - impl.evicted_pieces);
+            (void)cuMemUnmap(impl.overlay + rank * kChunkBytes, impl.sizes[piece]);
+        } else {
+            (void)cuMemUnmap(impl.home + impl.offsets[piece], impl.sizes[piece]);
+        }
+        (void)cuMemRelease(impl.handles[piece]);
+    }
+    (void)cuMemAddressFree(impl.home, impl.arena_reserved);
+    (void)cuMemAddressFree(impl.overlay, impl.window_reserved);
+}
+
+DeviceSpan EvictableWeightPool::arena() const noexcept {
+    return DeviceSpan{reinterpret_cast<void*>(impl_->home), impl_->config.arena_bytes};
+}
+
+std::size_t EvictableWeightPool::evictable_tail_bytes() const noexcept {
+    return impl_->arena_reserved - impl_->tail_begin;
+}
+
+std::size_t EvictableWeightPool::window_capacity_bytes() const noexcept {
+    return impl_->window_reserved;
+}
+
+std::size_t EvictableWeightPool::mirror_bytes() const noexcept { return impl_->mirror_extent; }
+
+bool EvictableWeightPool::mirror_captured() const noexcept { return impl_->mirror_captured; }
+
+bool EvictableWeightPool::transaction_open() const noexcept {
+    return impl_->evicted_pieces != 0;
+}
+
+bool EvictableWeightPool::poisoned() const noexcept { return impl_->poisoned; }
+
+void EvictableWeightPool::capture_window_mirror(cudaStream_t stream) {
+    Impl& impl = *impl_;
+    if (impl.mirror_captured) {
+        throw std::logic_error("evictable pool window mirror was already captured");
+    }
+    if (impl.mirror_extent != 0) {
+        impl.mirror = std::make_unique<PinnedHostBuffer>(impl.mirror_extent);
+        CUDA_CHECK(cudaMemcpyAsync(impl.mirror->data(),
+                                   reinterpret_cast<void*>(impl.home + impl.mirror_begin),
+                                   impl.mirror_extent, cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+    }
+    impl.mirror_captured = true;
+}
+
+EvictableWeightPool::Transaction EvictableWeightPool::evict(std::size_t bytes,
+                                                            cudaStream_t stream) {
+    Impl& impl = *impl_;
+    if (!impl.mirror_captured) {
+        throw std::logic_error("evictable pool has no window mirror; capture it after load");
+    }
+    if (impl.poisoned) {
+        throw std::runtime_error("evictable pool is poisoned by a failed restore");
+    }
+    if (impl.evicted_pieces != 0) {
+        throw std::logic_error("evictable pool transaction is already open");
+    }
+    if (bytes == 0) { throw std::invalid_argument("evictable pool cannot evict zero bytes"); }
+    const std::size_t chunks = (bytes + kChunkBytes - 1) / kChunkBytes;
+    const std::size_t extent = chunks * kChunkBytes;
+    if (extent > impl.window_reserved) {
+        throw std::invalid_argument("evictable pool request exceeds the window capacity: " +
+                                    std::to_string(bytes) + " bytes");
+    }
+    // The borrowed chunks may still be read by in-flight work on either stream.
+    CUDA_CHECK(cudaStreamSynchronize(impl.device.stream));
+    CUDA_CHECK(cudaStreamSynchronize(impl.device.transfer_stream));
+
+    const auto start        = Clock::now();
+    const std::size_t first = impl.handles.size() - chunks;
+    for (std::size_t rank = 0; rank < chunks; ++rank) {
+        const std::size_t piece = first + rank;
+        NINFER_CU_CHECK(cuMemUnmap(impl.home + impl.offsets[piece], impl.sizes[piece]));
+        impl.map_overlay(piece, rank);
+    }
+    impl.evicted_pieces = chunks;
+    return Transaction(*this, DeviceSpan{reinterpret_cast<void*>(impl.overlay), extent}, stream,
+                       seconds_since(start));
+}
+
+void EvictableWeightPool::restore(Transaction& transaction) noexcept {
+    Impl& impl = *impl_;
+    if (impl.evicted_pieces == 0) { return; }
+    const auto start         = Clock::now();
+    const std::size_t chunks = impl.evicted_pieces;
+    const std::size_t first  = impl.handles.size() - chunks;
+    try {
+        for (std::size_t rank = 0; rank < chunks; ++rank) {
+            const std::size_t piece = first + rank;
+            NINFER_CU_CHECK(cuMemUnmap(impl.overlay + rank * kChunkBytes, impl.sizes[piece]));
+            impl.map_home(piece);
+        }
+        // Only the borrowed chunks were dirtied, and only bytes below arena_bytes hold weights.
+        const std::size_t evicted_begin = impl.offsets[first];
+        const std::size_t evicted_end   = std::min(impl.config.arena_bytes, impl.arena_reserved);
+        if (evicted_end > evicted_begin) {
+            CUDA_CHECK(cudaMemcpyAsync(
+                reinterpret_cast<void*>(impl.home + evicted_begin),
+                static_cast<const std::byte*>(impl.mirror->data()) +
+                    (evicted_begin - impl.mirror_begin),
+                evicted_end - evicted_begin, cudaMemcpyHostToDevice, transaction.stream_));
+        }
+        CUDA_CHECK(cudaStreamSynchronize(transaction.stream_));
+    } catch (const std::exception& error) {
+        impl.poisoned = true;
+        std::fprintf(stderr,
+                     "ninfer: evictable weight pool restore failed (%s); the weights are no "
+                     "longer trustworthy\n",
+                     error.what());
+    } catch (...) {
+        impl.poisoned = true;
+        std::fprintf(stderr, "ninfer: evictable weight pool restore failed; the weights are no "
+                             "longer trustworthy\n");
+    }
+    impl.evicted_pieces                = 0;
+    transaction.stats_.restore_seconds = seconds_since(start);
+}
+
+EvictableWeightPool::Transaction::Transaction(EvictableWeightPool& pool, DeviceSpan leased,
+                                              cudaStream_t stream, double evict_seconds) noexcept
+    : pool_(&pool), leased_(leased), stream_(stream) {
+    stats_.evict_seconds = evict_seconds;
+    stats_.mapped_bytes  = leased.bytes;
+}
+
+EvictableWeightPool::Transaction::~Transaction() { close(); }
+
+EvictableWeightPool::Transaction::Transaction(Transaction&& other) noexcept
+    : pool_(other.pool_), leased_(other.leased_), stream_(other.stream_), stats_(other.stats_) {
+    other.pool_ = nullptr;
+}
+
+EvictableWeightPool::Transaction&
+EvictableWeightPool::Transaction::operator=(Transaction&& other) noexcept {
+    if (this != &other) {
+        close();
+        pool_       = other.pool_;
+        leased_     = other.leased_;
+        stream_     = other.stream_;
+        stats_      = other.stats_;
+        other.pool_ = nullptr;
+    }
+    return *this;
+}
+
+void EvictableWeightPool::Transaction::close() noexcept {
+    if (pool_ == nullptr) { return; }
+    pool_->restore(*this);
+    pool_ = nullptr;
+}
+
+} // namespace ninfer

--- a/src/core/evictable_weight_pool.h
+++ b/src/core/evictable_weight_pool.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "core/arena.h"
+#include "core/device.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace ninfer {
+
+// VMM-backed weight arena whose evict-ranked tail can be borrowed for a bounded window. The
+// physical chunks behind the arena suffix are unmapped from their stable home addresses and
+// remapped into a reserved overlay range, so a transaction hands out device memory without a single
+// allocation and captured graphs stay valid because the home mapping never moves. Closing the
+// transaction remaps the chunks home and re-uploads only the dirtied extent from a pinned mirror.
+//
+// evict() quiesces both streams of the owning DeviceContext before remapping. The caller
+// guarantees that no other stream touches the arena while a transaction is open.
+class EvictableWeightPool {
+public:
+    static constexpr std::size_t kChunkBytes = 16ULL * 1024ULL * 1024ULL;
+
+    struct Config {
+        std::size_t arena_bytes           = 0; // weights arena capacity
+        std::size_t evictable_tail_bytes  = 0; // arena suffix holding evict-ranked tensors
+        std::size_t window_capacity_bytes = 0; // largest extent one transaction may borrow
+    };
+
+    struct TransactionStats {
+        double evict_seconds     = 0.0;
+        double restore_seconds   = 0.0;
+        std::size_t mapped_bytes = 0;
+    };
+
+    class Transaction {
+    public:
+        Transaction() noexcept = default;
+        ~Transaction();
+
+        Transaction(const Transaction&)            = delete;
+        Transaction& operator=(const Transaction&) = delete;
+        Transaction(Transaction&& other) noexcept;
+        Transaction& operator=(Transaction&& other) noexcept;
+
+        [[nodiscard]] bool open() const noexcept { return pool_ != nullptr; }
+        [[nodiscard]] DeviceSpan leased() const noexcept { return leased_; }
+        [[nodiscard]] const TransactionStats& stats() const noexcept { return stats_; }
+
+        // Remaps the borrowed chunks home and re-uploads the dirtied extent. Never throws: a
+        // failure poisons the pool, which the owner must treat as fatal for the weights.
+        void close() noexcept;
+
+    private:
+        friend class EvictableWeightPool;
+
+        Transaction(EvictableWeightPool& pool, DeviceSpan leased, cudaStream_t stream,
+                    double evict_seconds) noexcept;
+
+        EvictableWeightPool* pool_ = nullptr;
+        DeviceSpan leased_{};
+        cudaStream_t stream_ = nullptr;
+        TransactionStats stats_{};
+    };
+
+    [[nodiscard]] static bool supported(const DeviceContext& device);
+
+    EvictableWeightPool(DeviceContext& device, const Config& config);
+    ~EvictableWeightPool();
+
+    EvictableWeightPool(const EvictableWeightPool&)            = delete;
+    EvictableWeightPool& operator=(const EvictableWeightPool&) = delete;
+
+    // Stable home mapping backing the weights arena for the process lifetime.
+    [[nodiscard]] DeviceSpan arena() const noexcept;
+    [[nodiscard]] std::size_t evictable_tail_bytes() const noexcept;
+    [[nodiscard]] std::size_t window_capacity_bytes() const noexcept;
+    [[nodiscard]] std::size_t mirror_bytes() const noexcept;
+    [[nodiscard]] bool mirror_captured() const noexcept;
+    [[nodiscard]] bool transaction_open() const noexcept;
+    [[nodiscard]] bool poisoned() const noexcept;
+
+    // Pins a copy of every tail byte a window can dirty. Call exactly once after the weights
+    // landed and the upload stream drained.
+    void capture_window_mirror(cudaStream_t stream);
+
+    // Borrows ceil(bytes / kChunkBytes) chunks from the arena end, mapped contiguously at the
+    // overlay range. Rejects requests beyond the window capacity and nested transactions.
+    [[nodiscard]] Transaction evict(std::size_t bytes, cudaStream_t stream);
+
+private:
+    struct Impl;
+
+    void restore(Transaction& transaction) noexcept;
+
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace ninfer

--- a/src/core/kv_loan.h
+++ b/src/core/kv_loan.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "core/evictable_kv_pool.h"
+#include "core/paged_kv_cache.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace ninfer {
+
+// Pages of one KV pool that a window borrows, and the arena granules those pages back. Only
+// granules that lie entirely inside the borrowed pages are collected, so a granule shared with a
+// live page is never unmapped.
+struct KVLoanPlan {
+    std::vector<KVPageRun> runs;
+    std::vector<std::size_t> granules;
+    std::size_t bytes = 0;
+};
+
+// Pages one granule spans in a plane, for planes whose stride divides the granularity evenly.
+// A plane that needs more than kMaxLoanUnitPages pages per granule (the tiny scale planes) is
+// never lent: its pages stay mapped and cost the loan nothing but a few per cent of yield.
+inline constexpr std::uint32_t kMaxLoanUnitPages = 256;
+
+[[nodiscard]] inline std::uint32_t kv_loan_unit_pages(const DeviceKVPagePool& pages,
+                                                      std::size_t granularity) {
+    std::uint32_t unit = 0;
+    for (std::size_t index = 0; index < pages.plane_count(); ++index) {
+        const auto stride = static_cast<std::size_t>(pages.plane(index).nb[3]);
+        if (stride == 0 || granularity % stride != 0) { continue; }
+        const std::size_t per_granule = granularity / stride;
+        if (per_granule > kMaxLoanUnitPages) { continue; }
+        unit = std::max(unit, static_cast<std::uint32_t>(per_granule));
+    }
+    return unit;
+}
+
+// Granules of the arena that the given page range covers entirely, across every lendable plane.
+inline void collect_loan_granules(const EvictableKVPool& arena, const DeviceKVPagePool& pages,
+                                  std::int32_t begin, std::uint32_t count,
+                                  std::vector<std::size_t>& out) {
+    const std::size_t granularity = arena.granularity();
+    const auto* const base        = static_cast<const std::byte*>(arena.arena().data);
+    for (std::size_t index = 0; index < pages.plane_count(); ++index) {
+        const auto stride = static_cast<std::size_t>(pages.plane(index).nb[3]);
+        if (stride == 0 || granularity % stride != 0 ||
+            granularity / stride > kMaxLoanUnitPages) {
+            continue;
+        }
+        const KVPlaneByteRange range = pages.plane_page_range(index, begin, count);
+        const auto offset  = static_cast<std::size_t>(static_cast<const std::byte*>(range.base) -
+                                                     base);
+        const std::size_t first = (offset + granularity - 1) / granularity;
+        const std::size_t last  = (offset + range.bytes) / granularity;
+        for (std::size_t granule = first; granule < last; ++granule) {
+            if (granule < arena.lendable_granules()) { out.push_back(granule); }
+        }
+    }
+}
+
+// Draws a loan of at least `bytes` from the highest free pages, growing one run at a time in
+// whole units. Returns an empty plan when the free pages cannot cover the request.
+[[nodiscard]] inline KVLoanPlan plan_kv_loan(const EvictableKVPool& arena,
+                                             const DeviceKVPagePool& pages, std::size_t bytes) {
+    KVLoanPlan plan;
+    const std::size_t granularity = arena.granularity();
+    const std::uint32_t unit      = kv_loan_unit_pages(pages, granularity);
+    if (bytes == 0 || unit == 0 || granularity == 0) { return plan; }
+    const std::size_t want = (bytes + granularity - 1) / granularity;
+    if (want > arena.window_capacity_bytes() / granularity) { return plan; }
+
+    const std::span<const KVPageRun> free_runs = pages.free_runs();
+    std::vector<std::size_t> collected;
+    for (auto run = free_runs.rbegin(); run != free_runs.rend() && plan.granules.size() < want;
+         ++run) {
+        const std::int32_t run_end = run->begin + static_cast<std::int32_t>(run->count);
+        std::uint32_t length       = 0;
+        collected.clear();
+        // Grow a suffix of this run until its granules cover what is still missing: the highest
+        // pages go first, which is where the allocator leaves the pool free the longest.
+        while (length < run->count && plan.granules.size() + collected.size() < want) {
+            length = std::min(run->count, length + unit);
+            collected.clear();
+            collect_loan_granules(arena, pages, run_end - static_cast<std::int32_t>(length),
+                                  length, collected);
+        }
+        if (collected.empty()) { continue; }
+        plan.runs.push_back(
+            KVPageRun{.begin = run_end - static_cast<std::int32_t>(length), .count = length});
+        plan.granules.insert(plan.granules.end(), collected.begin(), collected.end());
+    }
+    std::sort(plan.granules.begin(), plan.granules.end());
+    plan.granules.erase(std::unique(plan.granules.begin(), plan.granules.end()),
+                        plan.granules.end());
+    if (plan.granules.size() < want) { return KVLoanPlan{}; }
+    // Lease exactly what the window needs; the extra granules stay mapped inside the lent pages.
+    plan.granules.resize(want);
+    plan.bytes = want * granularity;
+    return plan;
+}
+
+} // namespace ninfer

--- a/src/core/paged_kv_cache.cpp
+++ b/src/core/paged_kv_cache.cpp
@@ -220,7 +220,7 @@ DeviceKVPagePool::DeviceKVPagePool(DeviceSpan backing, const DeviceKVPagePoolLay
     page_generations_.assign(spec_.page_group_count, 1);
     page_allocated_.assign(spec_.page_group_count, false);
     validation_marks_.assign(spec_.page_group_count, 0);
-    free_page_runs_.push_back(FreePageRun{.begin = 0, .count = spec_.page_group_count});
+    free_page_runs_.push_back(KVPageRun{.begin = 0, .count = spec_.page_group_count});
 }
 
 std::uint32_t DeviceKVPagePool::capacity_pages() const noexcept { return spec_.page_group_count; }
@@ -229,13 +229,70 @@ std::uint32_t DeviceKVPagePool::allocated_pages() const noexcept { return alloca
 
 std::uint32_t DeviceKVPagePool::reserved_pages() const noexcept { return reserved_pages_; }
 
+std::uint32_t DeviceKVPagePool::usable_pages() const noexcept {
+    return capacity_pages() - lent_pages_;
+}
+
+std::uint32_t DeviceKVPagePool::lent_pages() const noexcept { return lent_pages_; }
+
 std::uint32_t DeviceKVPagePool::available_pages() const noexcept {
-    return capacity_pages() - allocated_pages_ - reserved_pages_;
+    return usable_pages() - allocated_pages_ - reserved_pages_;
 }
 
 std::size_t DeviceKVPagePool::plane_count() const noexcept { return planes_.size(); }
 
 const Tensor& DeviceKVPagePool::plane(std::size_t index) const { return planes_.at(index); }
+
+std::span<const KVPageRun> DeviceKVPagePool::free_runs() const noexcept {
+    return {free_page_runs_.data(), free_page_runs_.size()};
+}
+
+KVPlaneByteRange DeviceKVPagePool::plane_page_range(std::size_t plane_index,
+                                                    std::int32_t first_page,
+                                                    std::uint32_t count) const {
+    if (spec_.geometry.device_plane_order != PagedKVPlaneOrder::PageMajor) {
+        throw std::logic_error("Paged KV page ranges require page-major planes");
+    }
+    if (count == 0 || first_page < 0 ||
+        static_cast<std::int64_t>(first_page) + count > capacity_pages()) {
+        throw std::out_of_range("Paged KV page range is outside the pool");
+    }
+    const Tensor& plane          = planes_.at(plane_index);
+    const std::size_t page_bytes = static_cast<std::size_t>(plane.nb[3]);
+    return KVPlaneByteRange{.base  = static_cast<const std::byte*>(plane.data) +
+                                    static_cast<std::size_t>(first_page) * page_bytes,
+                            .bytes = page_bytes * count};
+}
+
+void DeviceKVPagePool::lend_pages(std::int32_t begin, std::uint32_t count) {
+    if (count == 0 || begin < 0 || static_cast<std::int64_t>(begin) + count > capacity_pages()) {
+        throw std::out_of_range("Paged KV loan is outside the pool");
+    }
+    const std::int64_t end = static_cast<std::int64_t>(begin) + count;
+    for (std::size_t index = 0; index < free_page_runs_.size(); ++index) {
+        const KVPageRun& run       = free_page_runs_[index];
+        const std::int64_t run_end = static_cast<std::int64_t>(run.begin) + run.count;
+        if (run.begin <= begin && end <= run_end) {
+            consume_free_run(index, begin, count);
+            lent_pages_ += count;
+            return;
+        }
+    }
+    throw std::invalid_argument("Paged KV loan does not cover wholly free pages");
+}
+
+void DeviceKVPagePool::return_pages(std::int32_t begin, std::uint32_t count) {
+    if (count == 0 || begin < 0 || static_cast<std::int64_t>(begin) + count > capacity_pages()) {
+        throw std::out_of_range("Paged KV loan return is outside the pool");
+    }
+    if (count > lent_pages_) {
+        throw std::invalid_argument("Paged KV loan return exceeds the lent pages");
+    }
+    for (std::uint32_t offset = 0; offset < count; ++offset) {
+        release_free_page(begin + static_cast<std::int32_t>(offset));
+    }
+    lent_pages_ -= count;
+}
 
 std::uint32_t
 DeviceKVPagePool::contiguous_run_count(std::span<const DeviceKVPageHandle> pages) const {
@@ -262,7 +319,7 @@ bool DeviceKVPagePool::can_resize_reservation(const DeviceKVPageReservation& res
     const std::uint64_t used = static_cast<std::uint64_t>(allocated_pages_) +
                                static_cast<std::uint64_t>(reserved_pages_ - reservation.pages_) +
                                new_reserved_pages;
-    return used <= capacity_pages();
+    return used <= usable_pages();
 }
 
 void DeviceKVPagePool::resize_reservation(DeviceKVPageReservation& reservation,
@@ -291,7 +348,7 @@ void DeviceKVPagePool::materialize(DeviceKVPageReservation& reservation,
         }
     }
     if (count == 0) { return; }
-    if (count > capacity_pages() - allocated_pages_) {
+    if (count > usable_pages() - allocated_pages_) {
         throw std::logic_error("Paged KV reservation invariant was violated");
     }
 
@@ -307,7 +364,7 @@ void DeviceKVPagePool::materialize(DeviceKVPageReservation& reservation,
     if (preferred && *preferred >= 0) {
         const auto upper = std::upper_bound(
             free_page_runs_.begin(), free_page_runs_.end(), *preferred,
-            [](std::int32_t page, const FreePageRun& run) { return page < run.begin; });
+            [](std::int32_t page, const KVPageRun& run) { return page < run.begin; });
         if (upper != free_page_runs_.begin()) {
             const auto candidate = upper - 1;
             const std::uint64_t run_end =
@@ -322,7 +379,7 @@ void DeviceKVPagePool::materialize(DeviceKVPageReservation& reservation,
     if (selected == free_page_runs_.size()) {
         const auto contiguous =
             std::find_if(free_page_runs_.begin(), free_page_runs_.end(),
-                         [count](const FreePageRun& run) { return run.count >= count; });
+                         [count](const KVPageRun& run) { return run.count >= count; });
         if (contiguous != free_page_runs_.end()) {
             selected       = static_cast<std::size_t>(contiguous - free_page_runs_.begin());
             selected_begin = contiguous->begin;
@@ -343,7 +400,7 @@ void DeviceKVPagePool::materialize(DeviceKVPageReservation& reservation,
         std::uint32_t remaining   = count;
         std::size_t consumed_runs = 0;
         for (std::size_t run_index = 0; remaining != 0; ++run_index) {
-            FreePageRun& run         = free_page_runs_[run_index];
+            KVPageRun& run         = free_page_runs_[run_index];
             const std::uint32_t take = std::min(remaining, run.count);
             for (std::uint32_t offset = 0; offset < take; ++offset) {
                 append_page(run.begin + static_cast<std::int32_t>(offset));
@@ -371,7 +428,7 @@ DeviceKVPageLease DeviceKVPagePool::materialize_one(DeviceKVPageReservation& res
     if (free_page_runs_.empty()) {
         throw std::logic_error("Paged KV reservation invariant was violated");
     }
-    FreePageRun& run        = free_page_runs_.front();
+    KVPageRun& run        = free_page_runs_.front();
     const std::int32_t page = run.begin++;
     if (--run.count == 0) { free_page_runs_.erase(free_page_runs_.begin()); }
     page_allocated_[static_cast<std::size_t>(page)] = true;
@@ -462,7 +519,7 @@ void DeviceKVPagePool::release_page(std::int32_t index, std::uint32_t generation
 void DeviceKVPagePool::consume_free_run(std::size_t run_index, std::int32_t begin,
                                         std::uint32_t count) noexcept {
     if (run_index >= free_page_runs_.size() || count == 0) { std::terminate(); }
-    FreePageRun& run                = free_page_runs_[run_index];
+    KVPageRun& run                = free_page_runs_[run_index];
     const std::int64_t run_end      = static_cast<std::int64_t>(run.begin) + run.count;
     const std::int64_t consumed_end = static_cast<std::int64_t>(begin) + count;
     if (begin < run.begin || consumed_end > run_end) { std::terminate(); }
@@ -479,7 +536,7 @@ void DeviceKVPagePool::consume_free_run(std::size_t run_index, std::int32_t begi
         run.count = static_cast<std::uint32_t>(begin - run.begin);
         return;
     }
-    const FreePageRun right{.begin = static_cast<std::int32_t>(consumed_end),
+    const KVPageRun right{.begin = static_cast<std::int32_t>(consumed_end),
                             .count = static_cast<std::uint32_t>(run_end - consumed_end)};
     run.count = static_cast<std::uint32_t>(begin - run.begin);
     free_page_runs_.insert(free_page_runs_.begin() + static_cast<std::ptrdiff_t>(run_index + 1),
@@ -489,7 +546,7 @@ void DeviceKVPagePool::consume_free_run(std::size_t run_index, std::int32_t begi
 void DeviceKVPagePool::release_free_page(std::int32_t index) noexcept {
     const auto next = std::lower_bound(
         free_page_runs_.begin(), free_page_runs_.end(), index,
-        [](const FreePageRun& run, std::int32_t page) { return run.begin < page; });
+        [](const KVPageRun& run, std::int32_t page) { return run.begin < page; });
     const bool joins_right = next != free_page_runs_.end() && index + 1 == next->begin;
     const bool joins_left =
         next != free_page_runs_.begin() &&
@@ -504,7 +561,7 @@ void DeviceKVPagePool::release_free_page(std::int32_t index) noexcept {
         next->begin = index;
         ++next->count;
     } else {
-        free_page_runs_.insert(next, FreePageRun{.begin = index, .count = 1});
+        free_page_runs_.insert(next, KVPageRun{.begin = index, .count = 1});
     }
 }
 

--- a/src/core/paged_kv_cache.h
+++ b/src/core/paged_kv_cache.h
@@ -86,6 +86,19 @@ struct DeviceKVPlaneLayout {
     TensorRegion storage;
 };
 
+// Consecutive physical pages of one pool. The free list is kept sorted and coalesced, so a run
+// is the natural unit for both allocation and lending.
+struct KVPageRun {
+    std::int32_t begin  = 0;
+    std::uint32_t count = 0;
+};
+
+// Device bytes one plane devotes to a page run.
+struct KVPlaneByteRange {
+    const void* base  = nullptr;
+    std::size_t bytes = 0;
+};
+
 struct DeviceKVPagePoolLayout {
     DeviceKVPagePoolSpec spec;
     std::vector<DeviceKVPlaneLayout> planes;
@@ -201,12 +214,26 @@ public:
 
     [[nodiscard]] const KVPageGeometry& geometry() const noexcept { return spec_.geometry; }
 
+    // Physical extent of the pool; page indices are validated against it and it never changes.
     [[nodiscard]] std::uint32_t capacity_pages() const noexcept;
+    // Pages the pool may still hand out: the physical extent minus the pages lent away.
+    [[nodiscard]] std::uint32_t usable_pages() const noexcept;
     [[nodiscard]] std::uint32_t allocated_pages() const noexcept;
     [[nodiscard]] std::uint32_t reserved_pages() const noexcept;
+    [[nodiscard]] std::uint32_t lent_pages() const noexcept;
     [[nodiscard]] std::uint32_t available_pages() const noexcept;
     [[nodiscard]] std::size_t plane_count() const noexcept;
     [[nodiscard]] const Tensor& plane(std::size_t index) const;
+    [[nodiscard]] std::span<const KVPageRun> free_runs() const noexcept;
+    // Device bytes one plane devotes to a run of consecutive pages. Page-major geometry only:
+    // a run is one contiguous block there, which is what makes a run lendable.
+    [[nodiscard]] KVPlaneByteRange plane_page_range(std::size_t plane, std::int32_t first_page,
+                                                    std::uint32_t count) const;
+
+    // Removes a wholly free run from circulation so its device memory can be lent elsewhere, and
+    // puts it back. The caller owns the memory only between these two calls.
+    void lend_pages(std::int32_t begin, std::uint32_t count);
+    void return_pages(std::int32_t begin, std::uint32_t count);
     [[nodiscard]] std::uint32_t
     contiguous_run_count(std::span<const DeviceKVPageHandle> pages) const;
 
@@ -255,20 +282,16 @@ private:
     void release_page(std::int32_t index, std::uint32_t generation) noexcept;
     void release_reservation(std::uint32_t pages) noexcept;
 
-    struct FreePageRun {
-        std::int32_t begin  = 0;
-        std::uint32_t count = 0;
-    };
-
     DeviceKVPagePoolSpec spec_;
     std::vector<Tensor> planes_;
-    std::vector<FreePageRun> free_page_runs_;
+    std::vector<KVPageRun> free_page_runs_;
     std::vector<std::uint32_t> page_generations_;
     std::vector<bool> page_allocated_;
     mutable std::vector<std::uint32_t> validation_marks_;
     mutable std::uint32_t validation_stamp_ = 0;
     std::uint32_t allocated_pages_          = 0;
     std::uint32_t reserved_pages_           = 0;
+    std::uint32_t lent_pages_               = 0;
 };
 
 struct DeviceKVPageReservationRequest {

--- a/src/runtime/engine/engine_core.h
+++ b/src/runtime/engine/engine_core.h
@@ -1819,7 +1819,12 @@ private:
                     if (slots_[*lane] == nullptr || !slots_[*lane]->is_prefilling()) {
                         throw std::logic_error("prefill owner has no active Engine request");
                     }
-                    prefill_runnable = !slots_[*lane]->capture_pending;
+                    // A lane whose image is still encoding in a concurrent window yields its
+                    // prefill unit; the decode of the other lanes runs meanwhile.
+                    prefill_runnable =
+                        !slots_[*lane]->capture_pending &&
+                        !(slots_[*lane]->sequence &&
+                          instance_.program->vision_pending(*slots_[*lane]->sequence));
                 }
                 const ExecutionAction action = scheduler_.choose_execution(
                     !membership.empty(), prefill_runnable, previous_unit_was_decode);

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -263,6 +263,8 @@ GenerationService::GenerationService(ServeOptions options, LoadProgress load_pro
     engine_options.prefill_chunk            = options_.prefill_chunk;
     engine_options.kv_cache                 = options_.kv_cache;
     engine_options.enable_vision            = options_.enable_vision;
+    engine_options.vision_residency         = options_.vision_residency;
+    engine_options.vision_max_merged_tokens = options_.vision_max_merged_tokens;
     engine_options.use_cuda_graph           = options_.use_cuda_graph;
     engine_options.speculative              = options_.speculative;
     engine_options.context_cache            = options_.context_cache;
@@ -439,6 +441,13 @@ GenerationOutcome GenerationService::run(PreparedRequest& prepared, const Stream
         prepared.prepare_seconds +
         std::max(0.0, result.timings.first_token_seconds - result.timings.prepare_seconds);
     outcome.metrics.vision_seconds  = result.timings.vision_seconds;
+    outcome.metrics.overlay_windows           = result.timings.overlay_windows;
+    outcome.metrics.overlay_exclusive_windows = result.timings.overlay_exclusive_windows;
+    outcome.metrics.overlay_window_seconds  = result.timings.overlay_window_seconds;
+    outcome.metrics.overlay_evict_seconds   = result.timings.overlay_evict_seconds;
+    outcome.metrics.overlay_restore_seconds = result.timings.overlay_restore_seconds;
+    outcome.metrics.overlay_evicted_bytes   = result.timings.overlay_evicted_bytes;
+    outcome.metrics.overlay_staged_bytes    = result.timings.overlay_staged_bytes;
     outcome.metrics.prefill_seconds = result.timings.prefill_seconds;
     outcome.metrics.decode_seconds  = result.timings.decode_seconds;
     outcome.metrics.total_seconds =

--- a/src/serve/generation_service.h
+++ b/src/serve/generation_service.h
@@ -28,6 +28,13 @@ struct GenerationMetrics {
     double ttft_seconds    = 0.0;
     double vision_seconds  = 0.0;
     double prefill_seconds = 0.0;
+    std::uint32_t overlay_windows           = 0;
+    std::uint32_t overlay_exclusive_windows = 0;
+    double overlay_window_seconds     = 0.0;
+    double overlay_evict_seconds      = 0.0;
+    double overlay_restore_seconds    = 0.0;
+    std::size_t overlay_evicted_bytes = 0;
+    std::size_t overlay_staged_bytes  = 0;
     double decode_seconds  = 0.0;
     double total_seconds   = 0.0;
     ninfer::GenerationEngineTiming engine_timing;

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -542,6 +542,21 @@ std::string format_request_done(const RequestLogContext& context,
         << " decode=" << rate(decode_tokens, metrics.decode_seconds)
         << " wall=" << seconds_str(metrics.total_seconds) << " host=" << std::setprecision(2)
         << request_host_exposed_seconds(metrics.engine_timing) * 1000.0 << "ms";
+    if (metrics.overlay_windows != 0) {
+        const auto mib = [](std::size_t bytes) {
+            return static_cast<double>(bytes) / (1024.0 * 1024.0);
+        };
+        out << " overlay=" << metrics.overlay_windows << "x"
+            << (metrics.overlay_exclusive_windows == metrics.overlay_windows ? "excl"
+                : metrics.overlay_exclusive_windows == 0                     ? "conc"
+                                                                            : "mixed")
+            << " " << std::setprecision(0)
+            << metrics.overlay_window_seconds * 1000.0 << "ms (evict " << std::setprecision(0)
+            << mib(metrics.overlay_evicted_bytes) << "MiB " << std::setprecision(1)
+            << metrics.overlay_evict_seconds * 1000.0 << "ms, restore " << std::setprecision(1)
+            << metrics.overlay_restore_seconds * 1000.0 << "ms, staged " << std::setprecision(0)
+            << mib(metrics.overlay_staged_bytes) << "MiB)" << std::setprecision(2);
+    }
     if (metrics.engine_timing.decode_rounds == 0) {
         out << " decode-host=n/a wait=n/a";
     } else {
@@ -651,6 +666,8 @@ std::string format_server_start_json(
                                                           {"bytes_read", load.artifact_bytes_read},
                                                           {"host_to_device_bytes", load.host_to_device_bytes},
                                                           {"peak_staging_bytes", load.peak_staging_bytes},
+                                                          {"pinned_weight_bytes", load.pinned_weight_bytes},
+                                                          {"overlay_window_bytes", load.overlay_window_bytes},
                                                           {"tensor_count", load.tensor_count},
                                                           {"resource_count", load.resource_count},
                                                           {"load_seconds", load.load_seconds},
@@ -780,6 +797,14 @@ std::string format_request_done_json(const std::string& server_instance_id, std:
         {"prepare", outcome.metrics.prepare_seconds}, {"ttft", outcome.metrics.ttft_seconds},
         {"vision", outcome.metrics.vision_seconds},   {"prefill", outcome.metrics.prefill_seconds},
         {"decode", outcome.metrics.decode_seconds},   {"total", outcome.metrics.total_seconds}};
+    record["vision_overlay"] = Json{{"windows", outcome.metrics.overlay_windows},
+                                    {"window_seconds", outcome.metrics.overlay_window_seconds},
+                                    {"evict_seconds", outcome.metrics.overlay_evict_seconds},
+                                    {"restore_seconds", outcome.metrics.overlay_restore_seconds},
+                                    {"evicted_bytes", outcome.metrics.overlay_evicted_bytes},
+                                    {"staged_bytes", outcome.metrics.overlay_staged_bytes},
+                                    {"exclusive_windows",
+                                     outcome.metrics.overlay_exclusive_windows}};
     record["engine_timing"]   = request_engine_timing_json(outcome.metrics.engine_timing);
     record["speculative"]     = speculative_json(outcome.metrics);
     record["materialization"] = materialization_json(outcome.metrics.materialization);

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -79,7 +79,8 @@ std::string serve_usage_text(const char* argv0) {
            "[--response-store-max-records N] [--response-store-max-mib N] "
            "[--kv-dtype bf16|int8|rk8v4|fp8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] [--default-thinking-budget N] "
-           "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
+           "[--vision] [--vision-residency resident|overlay] [--vision-max-merged N] "
+           "[--no-cuda-graph] [--no-prefix-reuse] "
            "[--lm-head-draft] [--no-thinking] [--preserve-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--min-p F] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
@@ -97,6 +98,10 @@ std::string serve_usage_text(const char* argv0) {
            "default\n"
            "       --log-stats-interval-ms defaults to 5000; 0 disables periodic throughput logs\n"
            "       --vision enables media and loads the fixed Vision GPU allocations\n"
+           "       --vision-residency overlay keeps the Vision tower in host memory and borrows "
+           "device memory per image\n"
+           "       --vision-max-merged bounds the merged tokens of one media item (default 16384); "
+           "larger media is downscaled\n"
            "       --kv-capacity auto leaves " +
            std::to_string(kDefaultKvCapacityHeadroomBytes / (1024ULL * 1024ULL)) +
            " MiB of sizing headroom\n"
@@ -283,6 +288,22 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.default_thinking_budget = static_cast<std::uint32_t>(budget);
         } else if (arg == "--vision") {
             options.enable_vision = true;
+        } else if (arg == "--vision-residency") {
+            const std::string_view mode = require_value("--vision-residency");
+            if (mode == "resident") {
+                options.vision_residency = VisionResidency::Resident;
+            } else if (mode == "overlay") {
+                options.vision_residency = VisionResidency::Overlay;
+            } else {
+                throw std::invalid_argument("--vision-residency must be resident or overlay");
+            }
+        } else if (arg == "--vision-max-merged") {
+            const std::uint64_t merged =
+                parse_u64(require_value("--vision-max-merged"), "vision-max-merged");
+            if (merged < 64 || merged > 16384) {
+                throw std::invalid_argument("--vision-max-merged must be in [64, 16384]");
+            }
+            options.vision_max_merged_tokens = static_cast<std::uint32_t>(merged);
         } else if (arg == "--no-cuda-graph") {
             options.use_cuda_graph = false;
         } else if (arg == "--no-prefix-reuse") {
@@ -359,6 +380,9 @@ ServeOptions parse_serve_options(int argc, char** argv) {
     product::validate_speculative_cli_options(options.speculative);
     if (options.speculative.backend == SpeculativeBackend::DFlash && options.enable_vision) {
         throw std::invalid_argument("--spec dflash cannot be combined with --vision");
+    }
+    if (options.vision_residency == VisionResidency::Overlay && !options.enable_vision) {
+        throw std::invalid_argument("--vision-residency overlay requires --vision");
     }
     if (default_max_tokens_explicit) {
         if (options.default_max_tokens <= 0) {

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -45,6 +45,8 @@ struct ServeOptions {
     SpeculativeOptions speculative;
     ContextCacheOptions context_cache;
     bool enable_vision      = false;
+    VisionResidency vision_residency       = VisionResidency::Resident;
+    std::uint32_t vision_max_merged_tokens = 16384;
     bool use_cuda_graph     = true;
     bool allow_prefix_reuse = true;
     bool enable_thinking =

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
@@ -21,6 +21,9 @@ struct FrontendOptions {
     std::size_t media_live_bytes                = kDefaultMediaLiveBytes;
     std::uint32_t media_preprocess_threads      = 0;
     std::uint32_t max_cache_markers_per_request = 4;
+    // Largest merged-token count one media item may occupy; larger media is downscaled at
+    // preprocessing instead of being rejected. Zero leaves the artifact's pixel ceilings.
+    std::uint32_t vision_max_merged_tokens = 16384;
 };
 
 struct FrontendResources;

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/model_view.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/model_view.h
@@ -98,6 +98,7 @@ struct ModelView {
     std::optional<MtpLayer> mtp;
     std::optional<DFlashPayload> dflash;
     std::optional<VisionWeights> vision;
+    std::optional<VisionOverlayAssets> vision_overlay;
 };
 
 } // namespace targets::qwen3_6

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
@@ -168,6 +168,10 @@ public:
     SequencePlanner& operator=(const SequencePlanner&) = delete;
 
     [[nodiscard]] const runtime::SequenceCapacityCurve& capacity_curve() const noexcept;
+    // Device bytes one overlay vision window needs beyond the streamed weights: the encode
+    // workspace peak plus the output handoff for the planned merged-token budget. Zero without
+    // vision.
+    [[nodiscard]] std::size_t vision_window_bytes() const noexcept;
     [[nodiscard]] SequencePlan<Variant> finalize(std::uint32_t main_page_groups) &&;
 
 public:
@@ -673,6 +677,8 @@ public:
     progress_context_transaction(runtime::CancellationFlagView cancellation);
     void finalize_context_transaction() noexcept;
     [[nodiscard]] bool has_context_transaction() const noexcept;
+    // True while the sequence waits for an image encoding in a concurrent window.
+    [[nodiscard]] bool vision_pending(SequenceHandle<Variant> sequence) const noexcept;
     [[nodiscard]] PrefillProgress<Variant>
     advance_prefill(SequenceHandle<Variant> sequence,
                     runtime::ExecutionTiming* failed_timing = nullptr);

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h
@@ -5,11 +5,16 @@
 namespace ninfer::targets::qwen3_6 {
 
 struct StartupFeatures {
-    bool vision                    = false;
-    SpeculativeBackend speculative = SpeculativeBackend::None;
-    ProposalHead proposal_head     = ProposalHead::Full;
+    bool vision                      = false;
+    VisionResidency vision_residency = VisionResidency::Resident;
+    SpeculativeBackend speculative   = SpeculativeBackend::None;
+    ProposalHead proposal_head       = ProposalHead::Full;
 
     bool operator==(const StartupFeatures&) const = default;
+
+    [[nodiscard]] bool overlay_vision() const noexcept {
+        return vision && vision_residency == VisionResidency::Overlay;
+    }
 
     [[nodiscard]] bool speculative_enabled() const noexcept {
         return speculative != SpeculativeBackend::None;
@@ -26,9 +31,10 @@ struct StartupFeatures {
 
 [[nodiscard]] inline StartupFeatures startup_features(const EngineOptions& options) noexcept {
     return StartupFeatures{
-        .vision        = options.enable_vision,
-        .speculative   = options.speculative.backend,
-        .proposal_head = options.speculative.proposal_head,
+        .vision           = options.enable_vision,
+        .vision_residency = options.vision_residency,
+        .speculative      = options.speculative.backend,
+        .proposal_head    = options.speculative.proposal_head,
     };
 }
 

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/vision.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/vision.h
@@ -5,9 +5,15 @@
 
 #include <array>
 #include <cstddef>
+#include <span>
+
+namespace ninfer {
+class EvictableWeightPool;
+}
 
 namespace ninfer::artifact {
 class MaterializedArtifact;
+struct MaterializationPlan;
 }
 
 namespace ninfer::targets::qwen3_6 {
@@ -91,6 +97,44 @@ struct VisionWeights {
     Weight merger_fc2;
     Tensor merger_fc2_bias;
 };
+
+// Vision weights whose payload pointers address pinned host memory. Distinct from VisionWeights
+// so a device-side VisionContext can never be bound over host pointers by mistake; the overlay
+// window rebases these onto its borrowed device staging.
+struct HostVisionWeights {
+    VisionWeights weights;
+};
+
+struct PinnedRange {
+    std::size_t offset = 0;
+    std::size_t bytes  = 0;
+};
+
+// Byte ranges of the vision groups inside the pinned weight block, used by the overlay window to
+// stage weights through borrowed device memory. Each range covers exactly the objects of its
+// group; slot_bytes is the largest single layer range.
+struct VisionOverlayLayout {
+    PinnedRange prelude; // patch embedding, its bias, position embedding
+    std::array<PinnedRange, VisionBackboneConfig::layers> layers{};
+    PinnedRange merger;        // merger fc1/fc2 (+biases) and merger norm
+    std::size_t slot_bytes    = 0;
+    std::size_t staging_bytes = 0; // prelude + merger + two layer slots, each 256-aligned
+};
+
+// Runtime assets the overlay window needs, published on the model view when the engine runs with
+// VisionResidency::Overlay.
+struct VisionOverlayAssets {
+    ninfer::EvictableWeightPool* pool = nullptr;
+    std::span<const std::byte> pinned_block;
+    HostVisionWeights host;
+    VisionOverlayLayout layout;
+    std::size_t window_capacity_bytes = 0;
+};
+
+[[nodiscard]] VisionOverlayLayout compute_vision_overlay_layout(
+    const VisionBackbonePlan& backbone, const VisionMergerInputPlan& merger_input,
+    artifact::ObjectHandle merger_fc2, artifact::ObjectHandle merger_fc2_bias,
+    const VisionMergerNormPlan& merger_norm, const artifact::MaterializationPlan& plan);
 
 [[nodiscard]] VisionBackbonePlan bind_vision_backbone(artifact::Binder& binder,
                                                       artifact::TensorPlacement placement);

--- a/src/targets/qwen3_6/impl/frontend/frontend.cpp
+++ b/src/targets/qwen3_6/impl/frontend/frontend.cpp
@@ -820,6 +820,7 @@ public:
             validate_registered_processor(processor);
             validate_registered_tokenizer(*tokenizer);
         }
+        fi::bound_merged_tokens(processor, options.vision_max_merged_tokens);
         for (const int token : tokenizer->default_stop_token_ids()) {
             if (!tokenizer->is_valid_token(token)) {
                 throw std::invalid_argument(

--- a/src/targets/qwen3_6/impl/frontend/processor.cpp
+++ b/src/targets/qwen3_6/impl/frontend/processor.cpp
@@ -887,6 +887,21 @@ std::size_t Processor::count_tokens(std::vector<ChatMessage> messages,
     return count;
 }
 
+void bound_merged_tokens(ProcessorOptions& options, std::uint64_t merged_tokens) {
+    if (merged_tokens == 0) { return; }
+    const auto factor_pixels =
+        static_cast<std::uint64_t>(kFactor) * static_cast<std::uint64_t>(kFactor);
+    if (merged_tokens > std::numeric_limits<std::uint64_t>::max() / (factor_pixels * kTemporal)) {
+        return;
+    }
+    const std::uint64_t image_pixels = merged_tokens * factor_pixels;
+    const std::uint64_t video_pixels = image_pixels * static_cast<std::uint64_t>(kTemporal);
+    options.image_max_pixels         = std::min(options.image_max_pixels, image_pixels);
+    options.video_max_pixels         = std::min(options.video_max_pixels, video_pixels);
+    options.image_min_pixels         = std::min(options.image_min_pixels, options.image_max_pixels);
+    options.video_min_pixels         = std::min(options.video_min_pixels, options.video_max_pixels);
+}
+
 ProcessedInput Processor::process(std::vector<ChatMessage> messages,
                                   ChatRenderOptions render_options,
                                   const PreparationControl& control,

--- a/src/targets/qwen3_6/impl/frontend/processor.h
+++ b/src/targets/qwen3_6/impl/frontend/processor.h
@@ -97,6 +97,10 @@ struct ProcessorOptions {
     int video_max_frames                   = 768;
 };
 
+// Clamps the smart-resize pixel ceilings so one image, or one two-frame video group, never
+// exceeds merged_tokens after resizing; oversized media downscales instead of being rejected.
+void bound_merged_tokens(ProcessorOptions& options, std::uint64_t merged_tokens);
+
 struct ProcessedInput {
     std::vector<int> input_ids;
     std::vector<std::uint8_t> token_types;

--- a/src/targets/qwen3_6/impl/runtime/api_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/api_impl.h
@@ -72,6 +72,15 @@ const runtime::SequenceCapacityCurve& SequencePlanner<Variant>::capacity_curve()
 }
 
 template <>
+std::size_t SequencePlanner<Variant>::vision_window_bytes() const noexcept {
+    if (impl_ == nullptr || impl_->minimum == nullptr || !impl_->minimum->workspace.vision) {
+        return 0;
+    }
+    const auto& vision = *impl_->minimum->workspace.vision;
+    return vision.encode_peak_bytes + vision.handoff_capacity_bytes;
+}
+
+template <>
 SequencePlan<Variant> SequencePlanner<Variant>::finalize(std::uint32_t main_page_groups) && {
     if (impl_ == nullptr) { throw std::logic_error("sequence planner is empty"); }
     return SequencePlan<Variant>(detail::NINFER_QWEN36_RUNTIME_NS::finalize_sequence_plan_impl(
@@ -274,6 +283,11 @@ void Program<Variant>::finalize_context_transaction() noexcept {
 template <>
 bool Program<Variant>::has_context_transaction() const noexcept {
     return impl_->has_context_transaction();
+}
+
+template <>
+bool Program<Variant>::vision_pending(SequenceHandle<Variant> sequence) const noexcept {
+    return impl_->vision_pending(sequence);
 }
 
 template <>

--- a/src/targets/qwen3_6/impl/runtime/layouts.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts.h
@@ -41,6 +41,9 @@ struct PersistentLayout {
     TensorLayout sampling_config;
     std::size_t bytes            = 0;
     std::size_t kv_payload_bytes = 0;
+    // Arena offset just past the last page-major KV plane. Everything a vision window may borrow
+    // lies below it; block tables and other stores interleaved there are simply never selected.
+    std::size_t lendable_kv_end_bytes = 0;
 };
 
 struct VisionWorkspacePlan {
@@ -61,6 +64,9 @@ struct WorkspacePlan {
     std::size_t dflash_round     = 0;
     std::size_t general_capacity = 0;
     std::optional<VisionWorkspacePlan> vision;
+    // False in overlay residency: the vision encode workspace and handoff are borrowed per
+    // window instead of being folded into capacity.
+    bool vision_resident = true;
     std::size_t capacity = 0;
 };
 
@@ -78,6 +84,7 @@ struct SequencePlanningInputs {
     bool kv_rotate_v                       = false;
     ProposalHead proposal_head             = ProposalHead::Full;
     StartupFeatures features;
+    std::uint32_t vision_max_merged = 16384;
     bool use_cuda_graph = true;
     int device          = 0;
     ContextCacheOptions context_cache;
@@ -104,6 +111,7 @@ struct SequencePlanImpl<NINFER_QWEN36_VARIANT> {
     bool kv_rotate_v                       = false;
     ProposalHead proposal_head             = ProposalHead::Full;
     StartupFeatures features;
+    std::uint32_t vision_max_merged = 16384;
     bool use_cuda_graph = true;
     int device          = 0;
     ContextCacheOptions context_cache;

--- a/src/targets/qwen3_6/impl/runtime/layouts_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts_impl.h
@@ -263,6 +263,18 @@ PersistentLayout persistent_layout(const SequencePlanImpl& plan) {
     out.bytes = builder.finish(kArenaAlign, "persistent layout");
     out.kv_payload_bytes =
         out.decoder.kv_payload_bytes() + (out.dflash ? out.dflash->kv_payload_bytes() : 0);
+    const auto plane_end = [](const qwen3_6::PagedKVCacheLayout& cache) {
+        std::size_t end = 0;
+        if (cache.pages.spec.geometry.device_plane_order != PagedKVPlaneOrder::PageMajor) {
+            return end;
+        }
+        for (const DeviceKVPlaneLayout& plane : cache.pages.planes) {
+            end = std::max(end, plane.storage.region.offset + plane.storage.region.bytes);
+        }
+        return end;
+    };
+    out.lendable_kv_end_bytes = std::max(
+        plane_end(out.decoder.text_kv), out.decoder.mtp_kv ? plane_end(*out.decoder.mtp_kv) : 0);
     return out;
 }
 
@@ -289,7 +301,8 @@ WorkspacePlan build_workspace_plan(const SequencePlanImpl& plan) {
 
     const auto text_common_root = [&](WorkspaceLayoutBuilder& layout, std::int32_t tokens) {
         (void)workspace_recipe::text_prefill_roots<TextConfig>(
-            layout, tokens, plan.features.vision ? 3 : 0, plan.features.vision ? tokens : 0);
+            layout, tokens, plan.features.vision ? 3 : 0, plan.features.vision ? tokens : 0,
+            plan.features.overlay_vision());
     };
     const auto attention_stage = [&](WorkspaceLayoutBuilder& layout, std::int32_t first,
                                      std::int32_t last, qwen3_6::TextPhase phase,
@@ -579,10 +592,13 @@ WorkspacePlan build_workspace_plan(const SequencePlanImpl& plan) {
                                      out.mtp_round, out.dflash_context, out.dflash_round});
     out.capacity         = out.general_capacity;
     if (plan.features.vision) {
-        const std::uint32_t merged = static_cast<std::uint32_t>(
-            std::min<std::uint64_t>(plan.capacity, kMaximumVisionItemTokens));
-        out.vision   = schedule::VisionContext::plan_workspace(merged, out.general_capacity);
-        out.capacity = std::max(out.capacity, out.vision->capacity_bytes);
+        const std::uint32_t merged = static_cast<std::uint32_t>(std::min<std::uint64_t>(
+            {plan.capacity, kMaximumVisionItemTokens, plan.vision_max_merged}));
+        out.vision          = schedule::VisionContext::plan_workspace(merged, out.general_capacity);
+        out.vision_resident = !plan.features.overlay_vision();
+        if (out.vision_resident) {
+            out.capacity = std::max(out.capacity, out.vision->capacity_bytes);
+        }
     }
     return out;
 }
@@ -672,6 +688,7 @@ std::unique_ptr<SequencePlanImpl> build_sequence_candidate(const SequencePlannin
     impl->speculative_backend = inputs.speculative_backend;
     impl->proposal_head       = inputs.proposal_head;
     impl->features            = inputs.features;
+    impl->vision_max_merged   = inputs.vision_max_merged;
     impl->use_cuda_graph      = inputs.use_cuda_graph;
     impl->device              = inputs.device;
     impl->context_cache       = inputs.context_cache;
@@ -762,6 +779,7 @@ make_sequence_planner_impl(DeviceContext& device, const EngineOptions& options,
         .kv_rotate_v         = kv_profile.rotate_v,
         .proposal_head       = options.speculative.proposal_head,
         .features            = qwen3_6::startup_features(options),
+        .vision_max_merged   = std::max<std::uint32_t>(1, options.vision_max_merged_tokens),
         .use_cuda_graph      = options.use_cuda_graph,
         .device              = options.device,
         .context_cache       = options.context_cache,

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -8,6 +8,7 @@
 #include "runtime/engine/context_cost.h"
 #include "ninfer/ops/gdn_replay.h"
 #include "ninfer/ops/sampling.h"
+#include "core/evictable_kv_pool.h"
 #include "core/decode_graph.h"
 #include <ninfer/targets/qwen3_6/prepared_prompt.h>
 
@@ -19,6 +20,7 @@
 #include "targets/qwen3_6/impl/runtime/prefix_identity.h"
 #include "targets/qwen3_6/impl/runtime/text_context.h"
 #include "targets/qwen3_6/impl/runtime/vision_context.h"
+#include "targets/qwen3_6/impl/runtime/vision_overlay.h"
 #include "targets/qwen3_6/impl/runtime/vision_prefill.h"
 
 #include <algorithm>
@@ -540,6 +542,9 @@ public:
     progress_context_transaction(runtime::CancellationFlagView cancellation);
     void finalize_context_transaction() noexcept;
     [[nodiscard]] bool has_context_transaction() const noexcept;
+    // True while this sequence waits for an image it submitted to a concurrent window: the lane
+    // must not be given a prefill unit, and every other lane keeps running.
+    [[nodiscard]] bool vision_pending(SequenceHandle sequence) const noexcept;
     [[nodiscard]] PrefillProgress advance_prefill(SequenceHandle sequence,
                                                   runtime::ExecutionTiming* failed_timing);
     [[nodiscard]] CaptureAssessment
@@ -602,11 +607,16 @@ public:
     const bool kv_rotate_v;
     const ProposalHead proposal_head;
     const bool vision_enabled;
+    // Non-null in overlay residency: pool, pinned tower and window layout from the model view.
+    const VisionOverlayAssets* const vision_overlay;
     const bool use_cuda_graph;
     const std::size_t kv_payload_bytes;
     const std::size_t graph_allowance_bytes;
     const WorkspacePlan workspace_plan;
 
+    // Overlay residency only: the persistent arena is VMM-backed so free KV granules can be lent
+    // to a vision window. Null everywhere else, where `persistent` owns a plain allocation.
+    std::unique_ptr<EvictableKVPool> kv_arena;
     DeviceArena persistent;
     DeviceArena workspace_storage;
     WorkspaceArena work;
@@ -656,6 +666,9 @@ public:
 
     std::size_t workspace_logical_peak_bytes = 0;
     std::size_t vision_handoff_peak_bytes    = 0;
+    // Overlay residency only: the one-window broker and the per-lane pinned result slots.
+    std::optional<schedule::VisionResidencyBroker> vision_broker;
+    std::optional<schedule::PinnedResultPool> vision_results;
 
 private:
     void advance_resource_revision() noexcept {

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -711,6 +711,31 @@ void instantiate_graph_family(DecodeGraphFamily& family, const char* label, Devi
     }
 }
 
+// Overlay residency backs the persistent arena with virtual memory so free KV granules can be
+// lent to a vision window. The lendable prefix ends past the last page-major KV plane; block
+// tables and the stores above it live in the same range but are never selected by the planner.
+std::unique_ptr<EvictableKVPool> make_kv_arena(DeviceContext& device,
+                                               const LoadedModelData& model,
+                                               const SequencePlanImpl& plan) {
+    if (!model.vision_overlay) { return nullptr; }
+    const std::size_t window      = model.vision_overlay->window_capacity_bytes;
+    const std::size_t granularity = EvictableKVPool::device_granularity(device);
+    if (window == 0 || granularity == 0 || plan.persistent.lendable_kv_end_bytes == 0) {
+        return nullptr;
+    }
+    // A KV cache smaller than one window can never fund a concurrent encode. The engine still
+    // runs: every window then borrows the weight tail, exactly as it did before this tier.
+    const std::size_t lendable =
+        (plan.persistent.lendable_kv_end_bytes / granularity) * granularity;
+    if (window > lendable) { return nullptr; }
+    return std::make_unique<EvictableKVPool>(
+        device, EvictableKVPool::Config{
+                    .arena_bytes           = plan.persistent.bytes,
+                    .lendable_prefix_bytes = plan.persistent.lendable_kv_end_bytes,
+                    .window_capacity_bytes = window,
+                });
+}
+
 } // namespace
 
 ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const SequencePlanImpl& plan,
@@ -724,10 +749,14 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
       kv_quant_group(plan.kv_quant_group), kv_packed_v(plan.kv_packed_v),
       kv_rotate_k(plan.kv_rotate_k), kv_rotate_v(plan.kv_rotate_v),
       proposal_head(plan.proposal_head),
-      vision_enabled(plan.features.vision), use_cuda_graph(plan.use_cuda_graph),
+      vision_enabled(plan.features.vision),
+      vision_overlay(model.vision_overlay ? &*model.vision_overlay : nullptr),
+      use_cuda_graph(plan.use_cuda_graph),
       kv_payload_bytes(plan.persistent.kv_payload_bytes),
       graph_allowance_bytes(plan.graph_allowance_bytes), workspace_plan(plan.workspace),
-      persistent(plan.persistent.bytes), workspace_storage(plan.workspace.capacity),
+      kv_arena(make_kv_arena(device_in, model_in, plan)),
+      persistent(kv_arena ? DeviceArena(kv_arena->arena()) : DeviceArena(plan.persistent.bytes)),
+      workspace_storage(plan.workspace.capacity),
       work(DeviceSpan{workspace_storage.base(), plan.workspace.general_capacity}),
       continuation_states(continuation_capacity), continuation_slots(continuation_capacity),
       shared_prefix_states(shared_prefix_capacity), shared_prefix_slots(shared_prefix_capacity),
@@ -755,7 +784,8 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
     if (model.features != plan.features || model.mtp.has_value() != plan.features.mtp() ||
         model.dflash.has_value() != plan.features.dflash() ||
         model.optimized_proposal.has_value() != plan.features.optimized_proposal() ||
-        model.vision.has_value() != plan.features.vision) {
+        model.vision.has_value() != (plan.features.vision && !plan.features.overlay_vision()) ||
+        model.vision_overlay.has_value() != plan.features.overlay_vision()) {
         throw std::invalid_argument(
             "Qwen3.6 loaded weights do not match the frozen startup features");
     }
@@ -767,9 +797,17 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
     }
     if (workspace_plan.general_capacity == 0 ||
         workspace_plan.vision.has_value() != vision_enabled ||
+        workspace_plan.vision_resident != !plan.features.overlay_vision() ||
         (workspace_plan.vision &&
          workspace_plan.vision->general_capacity_bytes != workspace_plan.general_capacity)) {
         throw std::invalid_argument("Qwen3.6 workspace plan does not match startup features");
+    }
+    if (vision_overlay != nullptr) {
+        if (vision_overlay->pool == nullptr || !workspace_plan.vision) {
+            throw std::invalid_argument("overlay vision assets are incomplete");
+        }
+        vision_broker.emplace(device, *vision_overlay->pool);
+        vision_results.emplace(max_concurrency, workspace_plan.vision->handoff_capacity_bytes);
     }
     const DeviceSpan backing = persistent.alloc_bytes(plan.persistent.bytes, 256);
     if (!plan.context_cache.max_private_continuations || !plan.context_cache.max_shared_prefixes) {
@@ -808,6 +846,15 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
     text_kv_addresses = std::make_unique<KVAddressSpaceStore>(
         *text_kv_pages, decoder->text_kv.execution_tables(), address_capacity,
         decoder->text_kv.execution_tables().logical_page_capacity());
+    if (vision_broker && kv_arena) {
+        // A loan changes the admission capacity, so it may not race a sealed plan: refuse one
+        // while a context transaction or a pressure-planning session is in flight, and advance
+        // the revision whenever the capacity moves.
+        vision_broker->enable_kv_tier(
+            *kv_arena, decoder->text_kv.page_pool(),
+            [this] { return !has_context_transaction() && !pressure_planning_active_; },
+            [this] { advance_resource_revision(); });
+    }
     state_images =
         std::make_unique<qwen3_6::StateImageDevicePool>(backing, plan.persistent.state_images);
     if (plan.context_cache.host_state_slots != 0) {
@@ -4094,10 +4141,21 @@ ProgramImplCore::reserve_materialization(AdmissionCandidate&& plan, PreparedProm
             if (!workspace_plan.vision) {
                 throw std::logic_error("Vision prefill has no startup workspace plan");
             }
-            request.prefill->vision = std::make_unique<schedule::VisionPrefillSession>(
-                device, model, DeviceSpan{workspace_storage.base(), workspace_storage.capacity()},
-                *workspace_plan.vision, request.prefill->prompt, *request.prefill->vision_plan,
-                vision_handoff_peak_bytes);
+            if (vision_overlay != nullptr) {
+                request.prefill->vision = std::make_unique<schedule::VisionPrefillSession>(
+                    device, *workspace_plan.vision, request.prefill->prompt,
+                    *request.prefill->vision_plan, vision_handoff_peak_bytes, *vision_broker,
+                    *vision_overlay, vision_results->acquire());
+                // Start the first image now so its window overlaps the decode rounds that run
+                // before this lane gets a prefill unit.
+                request.prefill->vision->submit_next_item();
+            } else {
+                request.prefill->vision = std::make_unique<schedule::VisionPrefillSession>(
+                    device, model,
+                    DeviceSpan{workspace_storage.base(), workspace_storage.capacity()},
+                    *workspace_plan.vision, request.prefill->prompt,
+                    *request.prefill->vision_plan, vision_handoff_peak_bytes);
+            }
         }
         request.prefill->elapsed_seconds =
             std::chrono::duration<double>(Clock::now() - host_started).count();
@@ -6778,6 +6836,13 @@ ProgramImplCore::shared_prefix_summary(const SharedPrefixState& shared) const {
     };
 }
 
+bool ProgramImplCore::vision_pending(SequenceHandle sequence) const noexcept {
+    if (!valid_sequence(sequence)) { return false; }
+    const std::uint32_t lane = ContractAccess::lane(sequence).value;
+    const RequestControl& request = requests[lane];
+    return request.prefill && request.prefill->vision && request.prefill->vision->vision_pending();
+}
+
 PrefillProgress ProgramImplCore::advance_prefill(SequenceHandle sequence,
                                                  runtime::ExecutionTiming* failed_timing) {
     if (pending_transaction_ || !valid_sequence(sequence)) {
@@ -8262,8 +8327,8 @@ detail::PhysicalResources ProgramImplCore::admission_capacity() const noexcept {
             {
                 .active_lanes     = max_concurrency,
                 .state_slots      = static_cast<std::uint32_t>(state_images->slot_count()),
-                .main_kv_pages    = decoder->text_kv.page_pool().capacity_pages(),
-                .backend_kv_pages = backend != nullptr ? backend->page_pool().capacity_pages() : 0U,
+                .main_kv_pages    = decoder->text_kv.page_pool().usable_pages(),
+                .backend_kv_pages = backend != nullptr ? backend->page_pool().usable_pages() : 0U,
             },
         .host =
             {
@@ -10213,6 +10278,16 @@ ProgramImplCore::advance_prefill(SequenceState& sequence, RequestControl& reques
         sequence.tail_hidden_valid      = true;
         request.timings.vision_seconds  = vision_seconds;
         request.timings.prefill_seconds = std::max(0.0, staged.elapsed_seconds - vision_seconds);
+        if (staged.vision) {
+            const schedule::VisionOverlayWindowStats overlay = staged.vision->overlay_stats();
+            request.timings.overlay_windows         = overlay.windows;
+            request.timings.overlay_window_seconds  = overlay.window_seconds;
+            request.timings.overlay_evict_seconds   = overlay.evict_seconds;
+            request.timings.overlay_restore_seconds = overlay.restore_seconds;
+            request.timings.overlay_evicted_bytes   = overlay.evicted_bytes;
+            request.timings.overlay_staged_bytes    = overlay.staged_bytes;
+            request.timings.overlay_exclusive_windows = overlay.exclusive_windows;
+        }
         staged.prompt.release_all_media_payloads();
         if (staged.vision) { staged.vision->retire_handoff(); }
 
@@ -10831,6 +10906,13 @@ MemorySummary ProgramImplCore::memory_summary() const noexcept {
             .handoff_capacity_bytes = workspace_plan.vision->handoff_capacity_bytes,
             .handoff_active_bytes   = active_handoff_bytes,
             .handoff_peak_bytes     = vision_handoff_peak_bytes,
+            .residency = vision_overlay != nullptr ? VisionResidency::Overlay
+                                                   : VisionResidency::Resident,
+            .window_capacity_bytes =
+                vision_overlay != nullptr ? vision_overlay->window_capacity_bytes : 0,
+            .pinned_weight_bytes =
+                vision_overlay != nullptr ? vision_overlay->pinned_block.size() : 0,
+            .mirror_bytes = vision_overlay != nullptr ? vision_overlay->pool->mirror_bytes() : 0,
         };
     }
     out.workspace_logical_peak_bytes = workspace_logical_peak_bytes;

--- a/src/targets/qwen3_6/impl/runtime/request_plan_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/request_plan_impl.h
@@ -936,7 +936,7 @@ std::optional<AdmissionCandidate> ProgramImplCore::inspect_lane(
                 const std::uint32_t required = pages_for_tokens(frontier);
                 const std::uint64_t final_without_release =
                     static_cast<std::uint64_t>(required) + active_pages;
-                const std::uint32_t capacity = pages.physical_pool().capacity_pages();
+                const std::uint32_t capacity = pages.physical_pool().usable_pages();
                 if (final_without_release <= capacity) { return true; }
                 if (!prefix_fork || frontier == 0 ||
                     frontier % static_cast<std::uint32_t>(kPagedKVPageSize) == 0 ||

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -1141,8 +1141,10 @@ TextContext::prefill_impl(std::span<const int> ids, const TextPrefill* text_pref
             }
 
             const std::int32_t rope_axes = multimodal != nullptr ? 3 : (rope_delta_ != 0 ? 1 : 0);
+            const bool overlay_staging   = !vision_chunk.host_embeddings.empty();
             const auto roots             = workspace_recipe::text_prefill_roots<TextConfig>(
-                work_, len, rope_axes, static_cast<std::int32_t>(local_scatter_indices.size()));
+                work_, len, rope_axes, static_cast<std::int32_t>(local_scatter_indices.size()),
+                overlay_staging);
             Tensor ids_device = roots.ids;
             copy_i32(ids.data() + t0, ids_device, s);
 
@@ -1177,8 +1179,30 @@ TextContext::prefill_impl(std::span<const int> ids, const TextPrefill* text_pref
             if (!local_scatter_indices.empty()) {
                 Tensor indices_device = roots.scatter_indices;
                 copy_i32(local_scatter_indices.data(), indices_device, s);
-                Tensor embeddings = vision_chunk.embeddings.slice(
-                    1, visual_begin, static_cast<std::int32_t>(local_scatter_indices.size()));
+                const auto count = static_cast<std::int32_t>(local_scatter_indices.size());
+                Tensor embeddings;
+                if (overlay_staging) {
+                    // Overlay residency keeps the item embeddings pinned on the host; only the
+                    // columns of this chunk travel to the device.
+                    const std::size_t column_bytes =
+                        static_cast<std::size_t>(TextConfig::hidden) * sizeof(std::uint16_t);
+                    // Stage the chunk's columns plus the following one: the shifted MTP input of
+                    // the chunk's last visual token is the next visual column.
+                    const auto merged = static_cast<std::int32_t>(vision_chunk.control->merged_count);
+                    const std::int32_t staged_columns =
+                        std::min<std::int32_t>(count + 1, merged - visual_begin);
+                    const std::size_t offset = static_cast<std::size_t>(visual_begin) * column_bytes;
+                    const std::size_t bytes  = static_cast<std::size_t>(staged_columns) * column_bytes;
+                    if (staged_columns < count || offset + bytes > vision_chunk.host_embeddings.size()) {
+                        throw std::logic_error("vision chunk columns exceed the item embeddings");
+                    }
+                    CUDA_CHECK(cudaMemcpyAsync(roots.visual_embeddings.data,
+                                               vision_chunk.host_embeddings.data() + offset, bytes,
+                                               cudaMemcpyHostToDevice, s));
+                    embeddings = roots.visual_embeddings.slice(1, 0, count);
+                } else {
+                    embeddings = vision_chunk.embeddings.slice(1, visual_begin, count);
+                }
                 ops::scatter(embeddings, indices_device, x, s);
             }
             if constexpr (Tap::enabled) { tap.begin(x); }
@@ -1250,9 +1274,15 @@ TextContext::prefill_impl(std::span<const int> ids, const TextPrefill* text_pref
                         if (!overlap.empty()) {
                             Tensor shifted_indices = workspace_recipe::visual_scatter_indices(
                                 work_, static_cast<std::int32_t>(overlap.size()));
-                            qwen3_6::detail::scatter_shifted_visual_embeddings(
-                                mtp_input_embeddings, vision_chunk.embeddings, overlap,
-                                shifted_indices, s);
+                            if (overlay_staging) {
+                                qwen3_6::detail::scatter_shifted_visual_embeddings(
+                                    mtp_input_embeddings, roots.visual_embeddings, overlap,
+                                    shifted_indices, s, static_cast<std::size_t>(visual_begin));
+                            } else {
+                                qwen3_6::detail::scatter_shifted_visual_embeddings(
+                                    mtp_input_embeddings, vision_chunk.embeddings, overlap,
+                                    shifted_indices, s);
+                            }
                         }
                     }
                     mtp_input_embeddings_ptr = &mtp_input_embeddings;

--- a/src/targets/qwen3_6/impl/runtime/text_prefill_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_prefill_impl.h
@@ -119,8 +119,22 @@ void mtp_bridge_multimodal(PrefillContext& state, const PreparedPromptData& prom
                 prompt.token_types[state.text_kv_base]) {
             throw std::logic_error("visual MTP bridge does not match Vision scatter metadata");
         }
-        visual_embedding =
-            chunk.embeddings.slice(1, static_cast<std::int32_t>(column - scatter.begin()), 1);
+        const auto column_index = static_cast<std::int32_t>(column - scatter.begin());
+        if (!chunk.host_embeddings.empty()) {
+            const std::size_t column_bytes =
+                static_cast<std::size_t>(TextConfig::hidden) * sizeof(std::uint16_t);
+            const std::size_t offset = static_cast<std::size_t>(column_index) * column_bytes;
+            if (offset + column_bytes > chunk.host_embeddings.size()) {
+                throw std::logic_error("visual MTP bridge column exceeds the item embeddings");
+            }
+            visual_embedding =
+                state.execution.work.alloc(DType::BF16, {TextConfig::hidden, 1});
+            CUDA_CHECK(cudaMemcpyAsync(visual_embedding.data, chunk.host_embeddings.data() + offset,
+                                       column_bytes, cudaMemcpyHostToDevice,
+                                       state.execution.device.stream));
+        } else {
+            visual_embedding = chunk.embeddings.slice(1, column_index, 1);
+        }
         composed_embedding = &visual_embedding;
     }
 

--- a/src/targets/qwen3_6/impl/runtime/vision_context.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_context.h
@@ -9,11 +9,13 @@
 #include "core/weight.h"
 #include <ninfer/targets/qwen3_6/vision_control.h>
 #include "targets/qwen3_6/impl/runtime/layouts.h"
+#include "targets/qwen3_6/impl/runtime/vision_overlay.h"
 #include "targets/qwen3_6/impl/runtime/vision_prefill.h"
 
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <span>
 #include <vector>
@@ -45,6 +47,11 @@ struct VisionScheduleConfig {
 class VisionContext {
 public:
     VisionContext(DeviceContext& device, const LoadedModelData& model);
+    // Binds an explicit weight view; the overlay window uses it with weights rebased onto its
+    // borrowed staging. `stream` overrides the compute stream, which lets a window encode beside
+    // the decode of other lanes; null means the device's main stream.
+    VisionContext(DeviceContext& device, const qwen3_6::VisionWeights& weights,
+                  cudaStream_t stream = nullptr);
 
     [[nodiscard]] static std::size_t workspace_bytes(const qwen3_6::VisionItemControl& item);
     [[nodiscard]] static std::size_t workspace_bytes(std::size_t patches,
@@ -53,8 +60,9 @@ public:
                                                             std::size_t general_capacity_bytes);
     [[nodiscard]] static Tensor bind_output(DeviceSpan backing, const VisionWorkspacePlan& plan,
                                             std::size_t merged_tokens);
+    // weight_stream, when given, gates each layer on its streamed upload (overlay window).
     void encode(const VisionItemView& item, Tensor& output, DeviceSpan backing,
-                const VisionWorkspacePlan& plan) const;
+                const VisionWorkspacePlan& plan, VisionWeightStream* weight_stream = nullptr) const;
 
 private:
     struct BlockW {
@@ -82,6 +90,7 @@ private:
     };
 
     DeviceContext& ctx_;
+    cudaStream_t stream_            = nullptr;
     const Weight* patch_embed_      = nullptr;
     const Tensor* patch_embed_bias_ = nullptr;
     const Tensor* position_embed_   = nullptr;
@@ -92,7 +101,10 @@ private:
 struct VisionChunk {
     std::int32_t length                       = 0;
     const qwen3_6::VisionItemControl* control = nullptr;
+    // Resident residency: the item's device handoff [out_hidden, merged].
     Tensor embeddings;
+    // Overlay residency: the item's pinned embeddings; the prefill uploads the chunk's columns.
+    std::span<const std::byte> host_embeddings;
 };
 
 class VisionPrefillSession {
@@ -101,8 +113,20 @@ public:
                          const VisionWorkspacePlan& workspace_plan,
                          qwen3_6::PreparedPromptData& prompt, const VisionPrefillPlan& plan,
                          std::size_t& handoff_peak_bytes);
+    // Overlay residency: items are encoded inside windows brokered by the Program.
+    VisionPrefillSession(DeviceContext& device, const VisionWorkspacePlan& workspace_plan,
+                         qwen3_6::PreparedPromptData& prompt, const VisionPrefillPlan& plan,
+                         std::size_t& handoff_peak_bytes, VisionResidencyBroker& broker,
+                         const qwen3_6::VisionOverlayAssets& assets, PinnedResultPool::Handle result);
+    ~VisionPrefillSession();
 
     [[nodiscard]] VisionChunk prepare_chunk(std::uint32_t begin, std::uint32_t nominal_length);
+    // Overlay residency: starts the encode of the next unencoded item ahead of its prefill unit,
+    // so its window overlaps the decode of other lanes. A no-op when a window is already open,
+    // when the item is encoded, or under resident residency; the synchronous path then stands.
+    void submit_next_item();
+    // True while a submitted item has not finished: the lane must not be given a prefill unit.
+    [[nodiscard]] bool vision_pending() const noexcept;
     void release_encoded_media_payloads() noexcept;
     void retire_handoff() noexcept;
     [[nodiscard]] double elapsed_seconds() const;
@@ -110,17 +134,23 @@ public:
     [[nodiscard]] std::size_t active_handoff_bytes() const noexcept {
         return active_handoff_bytes_;
     }
+    [[nodiscard]] VisionOverlayWindowStats overlay_stats() const noexcept;
 
 private:
+    void validate_plan() const;
+
     DeviceContext& device_;
     DeviceSpan workspace_;
     const VisionWorkspacePlan& workspace_plan_;
     qwen3_6::PreparedPromptData& prompt_;
     const VisionPrefillPlan& plan_;
     std::size_t& handoff_peak_bytes_;
-    VisionContext context_;
+    std::optional<VisionContext> context_;
+    std::unique_ptr<VisionOverlaySession> overlay_;
+    std::span<const std::byte> host_result_;
     std::size_t next_use_ = 0;
     std::optional<std::uint32_t> active_item_;
+    std::optional<std::uint32_t> submitted_item_;
     std::size_t active_handoff_bytes_ = 0;
     std::vector<std::uint32_t> encoded_payloads_pending_release_;
     std::vector<CudaEventTimer> timers_;

--- a/src/targets/qwen3_6/impl/runtime/vision_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_context_impl.h
@@ -1,5 +1,6 @@
 #include "targets/qwen3_6/impl/runtime/instance.h"
 #include "targets/qwen3_6/impl/runtime/vision_context.h"
+#include "targets/qwen3_6/impl/runtime/vision_overlay_impl.h"
 
 #include "core/device.h"
 #include "core/layout.h"
@@ -173,11 +174,15 @@ void copy_host(const void* src, Tensor& dst, cudaStream_t stream) {
 
 } // namespace
 
-VisionContext::VisionContext(DeviceContext& ctx, const LoadedModelData& weights) : ctx_(ctx) {
-    if (!weights.vision) {
-        throw std::invalid_argument("Vision execution was requested without materialized weights");
-    }
-    const auto& vision = *weights.vision;
+VisionContext::VisionContext(DeviceContext& ctx, const LoadedModelData& weights)
+    : VisionContext(ctx, weights.vision ? *weights.vision
+                                        : throw std::invalid_argument(
+                                              "Vision execution was requested without "
+                                              "materialized weights")) {}
+
+VisionContext::VisionContext(DeviceContext& ctx, const qwen3_6::VisionWeights& vision,
+                             cudaStream_t stream)
+    : ctx_(ctx), stream_(stream != nullptr ? stream : ctx.stream) {
     patch_embed_       = &vision.common.patch_embedding;
     patch_embed_bias_  = &vision.common.patch_embedding_bias;
     position_embed_    = &vision.common.position_embedding;
@@ -258,7 +263,8 @@ Tensor VisionContext::bind_output(DeviceSpan backing, const VisionWorkspacePlan&
 }
 
 void VisionContext::encode(const VisionItemView& item, Tensor& output, DeviceSpan backing,
-                           const VisionWorkspacePlan& plan) const {
+                           const VisionWorkspacePlan& plan,
+                           VisionWeightStream* weight_stream) const {
     if (item.control == nullptr) { throw std::invalid_argument("Vision item control is null"); }
     const qwen3_6::VisionItemControl& control = *item.control;
     const auto patches64                      = control.patch_count;
@@ -282,7 +288,7 @@ void VisionContext::encode(const VisionItemView& item, Tensor& output, DeviceSpa
     }
     const auto patches  = static_cast<std::int32_t>(patches64);
     const auto tokens   = static_cast<std::int32_t>(tokens64);
-    cudaStream_t stream = ctx_.stream;
+    cudaStream_t stream = stream_;
 
     Tensor position_ids = layout.position_ids.bind(backing);
     copy_host(control.position_ids.data(), position_ids, stream);
@@ -290,6 +296,7 @@ void VisionContext::encode(const VisionItemView& item, Tensor& output, DeviceSpa
     Tensor x          = layout.x.bind(backing);
     Tensor patch_bf16 = layout.patch_bf16.bind(backing);
     copy_host(item.patches.data(), patch_bf16, stream);
+    if (weight_stream != nullptr) { weight_stream->prelude_ready(stream); }
     ops::linear(patch_bf16, *patch_embed_, x, stream);
     ops::add_bias(*patch_embed_bias_, x, stream);
     // The artifact records the source table shape [rows,hidden], while Tensor's
@@ -304,6 +311,9 @@ void VisionContext::encode(const VisionItemView& item, Tensor& output, DeviceSpa
     ops::vision_pos_embed_add(position_table, pos_indices, pos_weights, x, stream);
     for (std::size_t layer = 0; layer < blocks_.size(); ++layer) {
         const BlockW& block = blocks_[layer];
+        if (weight_stream != nullptr) {
+            weight_stream->arrive(static_cast<std::uint32_t>(layer), stream);
+        }
         {
             Tensor attended = layout.attended.bind(backing);
             {
@@ -360,6 +370,7 @@ void VisionContext::encode(const VisionItemView& item, Tensor& output, DeviceSpa
     }
 
     Tensor normalized = layout.normalized.bind(backing);
+    if (weight_stream != nullptr) { weight_stream->merger_ready(stream); }
     ops::layer_norm(x, *merger_.norm_weight, *merger_.norm_bias, VisionScheduleConfig::norm_eps,
                     normalized, stream);
     Tensor merged = normalized.view({VisionScheduleConfig::merger_hidden, tokens});
@@ -378,12 +389,36 @@ VisionPrefillSession::VisionPrefillSession(DeviceContext& device, const LoadedMo
                                            const VisionPrefillPlan& plan,
                                            std::size_t& handoff_peak_bytes)
     : device_(device), workspace_(workspace), workspace_plan_(workspace_plan), prompt_(prompt),
-      plan_(plan), handoff_peak_bytes_(handoff_peak_bytes), context_(device, model) {
+      plan_(plan), handoff_peak_bytes_(handoff_peak_bytes) {
+    context_.emplace(device, model);
+    if (workspace_.data == nullptr || workspace_.bytes < workspace_plan_.capacity_bytes) {
+        throw std::invalid_argument("Vision prefill workspace plan is invalid");
+    }
+    validate_plan();
+}
+
+VisionPrefillSession::VisionPrefillSession(DeviceContext& device,
+                                           const VisionWorkspacePlan& workspace_plan,
+                                           qwen3_6::PreparedPromptData& prompt,
+                                           const VisionPrefillPlan& plan,
+                                           std::size_t& handoff_peak_bytes,
+                                           VisionResidencyBroker& broker,
+                                           const qwen3_6::VisionOverlayAssets& assets,
+                                           PinnedResultPool::Handle result)
+    : device_(device), workspace_{}, workspace_plan_(workspace_plan), prompt_(prompt),
+      plan_(plan), handoff_peak_bytes_(handoff_peak_bytes) {
+    overlay_ = std::make_unique<VisionOverlaySession>(device, broker, assets, workspace_plan,
+                                                      std::move(result));
+    validate_plan();
+}
+
+VisionPrefillSession::~VisionPrefillSession() = default;
+
+void VisionPrefillSession::validate_plan() const {
     if (plan_.control == nullptr || plan_.control->items.empty() || plan_.uses.empty()) {
         throw std::invalid_argument("Vision prefill plan has no suffix item spans");
     }
-    if (workspace_.data == nullptr || workspace_.bytes < workspace_plan_.capacity_bytes ||
-        plan_.max_merged_count == 0 || plan_.max_merged_count > workspace_plan_.max_merged_tokens) {
+    if (plan_.max_merged_count == 0 || plan_.max_merged_count > workspace_plan_.max_merged_tokens) {
         throw std::invalid_argument("Vision prefill workspace plan is invalid");
     }
     std::uint32_t previous_end = 0;
@@ -415,13 +450,15 @@ VisionPrefillSession::VisionPrefillSession(DeviceContext& device, const LoadedMo
         if (control.merged_count > plan_.max_merged_count) {
             throw std::invalid_argument("Vision suffix item exceeds its request workspace extent");
         }
-        const Tensor output =
-            VisionContext::bind_output(workspace_, workspace_plan_, control.merged_count);
+        const std::size_t output_bytes =
+            checked_mul(static_cast<std::size_t>(control.merged_count),
+                        static_cast<std::size_t>(VisionScheduleConfig::out_hidden) * 2,
+                        "item handoff bytes");
         const std::size_t patch_elements = checked_mul(
             control.patch_count, static_cast<std::size_t>(VisionScheduleConfig::patch_dim),
             "item patch elements");
         const auto& payload = prompt_.media_payloads[use.prepared_item_index];
-        if (output.bytes() > workspace_plan_.handoff_capacity_bytes || !payload ||
+        if (output_bytes > workspace_plan_.handoff_capacity_bytes || !payload ||
             payload->patch_elements != patch_elements) {
             throw std::invalid_argument("Vision suffix item storage has an invalid shape");
         }
@@ -435,8 +472,6 @@ VisionPrefillSession::VisionPrefillSession(DeviceContext& device, const LoadedMo
                      })) {
         throw std::invalid_argument("Vision request workspace extent has no matching suffix item");
     }
-    encoded_payloads_pending_release_.reserve(plan_.uses.size());
-    timers_.reserve(plan_.uses.size());
 }
 
 VisionChunk VisionPrefillSession::prepare_chunk(std::uint32_t begin, std::uint32_t nominal_length) {
@@ -461,21 +496,57 @@ VisionChunk VisionPrefillSession::prepare_chunk(std::uint32_t begin, std::uint32
         return VisionChunk{static_cast<std::int32_t>(end - begin), nullptr, {}};
     }
     const qwen3_6::VisionItemControl& control = plan_.control->items[active->control_index];
+    if (overlay_ != nullptr) {
+        if (!active_item_ || *active_item_ != active->prepared_item_index) {
+            if (submitted_item_ && *submitted_item_ == active->prepared_item_index) {
+                // Submitted ahead of this unit: the encode has already run beside other lanes.
+                host_result_ = overlay_->complete_item();
+                submitted_item_.reset();
+            } else {
+                const auto& payload = prompt_.media_payloads[active->prepared_item_index];
+                host_result_ =
+                    overlay_->encode_item(VisionItemView{payload->span(), &control}, control);
+            }
+            active_item_ = active->prepared_item_index;
+            encoded_payloads_pending_release_.push_back(active->prepared_item_index);
+        }
+        return VisionChunk{static_cast<std::int32_t>(end - begin), &control, Tensor{},
+                           host_result_};
+    }
     Tensor output = VisionContext::bind_output(workspace_, workspace_plan_, control.merged_count);
 
     if (!active_item_ || *active_item_ != active->prepared_item_index) {
         const auto& payload = prompt_.media_payloads[active->prepared_item_index];
         timers_.emplace_back(device_);
         timers_.back().start();
-        context_.encode(VisionItemView{payload->span(), &control}, output, workspace_,
-                        workspace_plan_);
+        context_->encode(VisionItemView{payload->span(), &control}, output, workspace_,
+                         workspace_plan_);
         timers_.back().record_stop();
         active_item_          = active->prepared_item_index;
         active_handoff_bytes_ = output.bytes();
         handoff_peak_bytes_   = std::max(handoff_peak_bytes_, active_handoff_bytes_);
         encoded_payloads_pending_release_.push_back(active->prepared_item_index);
     }
-    return VisionChunk{static_cast<std::int32_t>(end - begin), &control, output};
+    return VisionChunk{static_cast<std::int32_t>(end - begin), &control, output, {}};
+}
+
+void VisionPrefillSession::submit_next_item() {
+    // One pinned result slot per session: an item may only be submitted while no other item's
+    // embeddings are still being consumed by the prefill.
+    if (overlay_ == nullptr || overlay_->pending() || active_item_) { return; }
+    if (next_use_ >= plan_.uses.size()) { return; }
+    const std::uint32_t item = plan_.uses[next_use_].prepared_item_index;
+    const auto& payload      = prompt_.media_payloads[item];
+    if (!payload) { return; }
+    const qwen3_6::VisionItemControl& control =
+        plan_.control->items[plan_.uses[next_use_].control_index];
+    if (overlay_->submit_item(VisionItemView{payload->span(), &control}, control)) {
+        submitted_item_ = item;
+    }
+}
+
+bool VisionPrefillSession::vision_pending() const noexcept {
+    return overlay_ != nullptr && overlay_->pending() && !overlay_->item_ready();
 }
 
 void VisionPrefillSession::release_encoded_media_payloads() noexcept {
@@ -488,13 +559,20 @@ void VisionPrefillSession::release_encoded_media_payloads() noexcept {
 
 void VisionPrefillSession::retire_handoff() noexcept {
     active_item_.reset();
+    submitted_item_.reset();
     active_handoff_bytes_ = 0;
+    host_result_          = {};
 }
 
 double VisionPrefillSession::elapsed_seconds() const {
+    if (overlay_ != nullptr) { return overlay_->stats().window_seconds; }
     double milliseconds = 0.0;
     for (const CudaEventTimer& timer : timers_) { milliseconds += timer.elapsed_ms(); }
     return milliseconds / 1000.0;
+}
+
+VisionOverlayWindowStats VisionPrefillSession::overlay_stats() const noexcept {
+    return overlay_ != nullptr ? overlay_->stats() : VisionOverlayWindowStats{};
 }
 
 } // namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule

--- a/src/targets/qwen3_6/impl/runtime/vision_overlay.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_overlay.h
@@ -1,0 +1,286 @@
+#pragma once
+#include "targets/qwen3_6/impl/runtime/instance.h"
+// Qwen3.6 family runtime implementation; instantiated only by exact variants.
+
+#include "core/arena.h"
+#include "core/device.h"
+#include "core/evictable_kv_pool.h"
+#include "core/evictable_weight_pool.h"
+#include "core/kv_loan.h"
+#include "core/paged_kv_cache.h"
+#include <ninfer/targets/qwen3_6/vision.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule {
+
+struct VisionOverlayWindowStats {
+    double window_seconds     = 0.0;
+    double evict_seconds      = 0.0;
+    double restore_seconds    = 0.0;
+    std::size_t evicted_bytes = 0;
+    std::size_t staged_bytes  = 0;
+    std::uint32_t windows     = 0;
+    // Windows that had to borrow the weight tail, which stalls every other lane.
+    std::uint32_t exclusive_windows = 0;
+};
+
+class VisionResidencyBroker;
+
+// One open window, served either from free KV granules (tier 1: the text weights stay mapped, so
+// other lanes keep decoding) or from the evict-ranked weight tail (tier 2: exclusive, always
+// available because the tail is far larger than the largest window).
+class VisionWindow {
+public:
+    enum class Tier : std::uint8_t { KvGranules, WeightTail };
+
+    VisionWindow() noexcept = default;
+    ~VisionWindow();
+
+    VisionWindow(const VisionWindow&)            = delete;
+    VisionWindow& operator=(const VisionWindow&) = delete;
+    VisionWindow(VisionWindow&& other) noexcept;
+    VisionWindow& operator=(VisionWindow&& other) noexcept;
+
+    [[nodiscard]] bool open() const noexcept { return broker_ != nullptr; }
+    [[nodiscard]] Tier tier() const noexcept { return tier_; }
+    [[nodiscard]] DeviceSpan memory() const noexcept {
+        return tier_ == Tier::KvGranules ? kv_.leased() : weights_.leased();
+    }
+    [[nodiscard]] double open_seconds() const noexcept {
+        return tier_ == Tier::KvGranules ? kv_.stats().lease_seconds : weights_.stats().evict_seconds;
+    }
+    [[nodiscard]] double close_seconds() const noexcept {
+        return tier_ == Tier::KvGranules ? kv_.stats().return_seconds
+                                         : weights_.stats().restore_seconds;
+    }
+    [[nodiscard]] std::size_t borrowed_bytes() const noexcept {
+        return tier_ == Tier::KvGranules ? kv_.stats().mapped_bytes : weights_.stats().mapped_bytes;
+    }
+
+    // Returns the borrowed memory. Never throws: a failure poisons the owning pool.
+    void close() noexcept;
+
+private:
+    friend class VisionResidencyBroker;
+
+    VisionResidencyBroker* broker_ = nullptr;
+    Tier tier_                     = Tier::WeightTail;
+    EvictableWeightPool::Transaction weights_;
+    EvictableKVPool::Transaction kv_;
+    std::vector<KVPageRun> runs_;
+};
+
+// Program-owned arbiter of the single overlay window a device can hold. Tier 1 is offered only
+// while the KV tier is enabled and the free pages cover the request; otherwise the window falls
+// back to the weight tail, which makes it exclusive by construction: the text weights it borrows
+// are unmapped until the window closes.
+class VisionResidencyBroker {
+public:
+    VisionResidencyBroker(DeviceContext& device, EvictableWeightPool& pool) noexcept
+        : device_(device), pool_(pool) {}
+
+    // Offers free KV granules as the preferred currency. `can_lend` refuses a loan while the
+    // Program cannot afford a capacity change; `on_change` bumps the resource revision.
+    void enable_kv_tier(EvictableKVPool& arena, DeviceKVPagePool& pages,
+                        std::function<bool()> can_lend, std::function<void()> on_change) {
+        kv_arena_   = &arena;
+        kv_pages_   = &pages;
+        can_lend_   = std::move(can_lend);
+        on_change_  = std::move(on_change);
+    }
+
+    // Free KV granules only. Empty when the pool cannot fund the window, which is the signal
+    // that an asynchronous encode is not available for this item.
+    [[nodiscard]] std::optional<VisionWindow> try_acquire_kv(std::size_t bytes) {
+        require_closed();
+        if (kv_arena_ == nullptr || kv_pages_ == nullptr || kv_arena_->poisoned() ||
+            (can_lend_ && !can_lend_())) {
+            return std::nullopt;
+        }
+        KVLoanPlan plan = plan_kv_loan(*kv_arena_, *kv_pages_, bytes);
+        if (plan.granules.empty()) { return std::nullopt; }
+        for (const KVPageRun& run : plan.runs) { kv_pages_->lend_pages(run.begin, run.count); }
+        if (on_change_) { on_change_(); }
+        VisionWindow window;
+        window.broker_ = this;
+        window.tier_   = VisionWindow::Tier::KvGranules;
+        window.runs_   = std::move(plan.runs);
+        window.kv_     = kv_arena_->lease(plan.granules, device_.stream);
+        ++tier1_windows_;
+        return window;
+    }
+
+    // Free KV granules when they cover the window, the evict-ranked weight tail otherwise.
+    [[nodiscard]] VisionWindow acquire(std::size_t bytes) {
+        std::optional<VisionWindow> borrowed = try_acquire_kv(bytes);
+        if (borrowed) { return std::move(*borrowed); }
+        VisionWindow window;
+        window.broker_  = this;
+        window.tier_    = VisionWindow::Tier::WeightTail;
+        window.weights_ = pool_.evict(bytes, device_.stream);
+        ++tier2_windows_;
+        return window;
+    }
+
+    [[nodiscard]] bool poisoned() const noexcept {
+        return pool_.poisoned() || (kv_arena_ != nullptr && kv_arena_->poisoned());
+    }
+    [[nodiscard]] std::size_t window_capacity_bytes() const noexcept {
+        return pool_.window_capacity_bytes();
+    }
+    [[nodiscard]] std::uint32_t tier1_windows() const noexcept { return tier1_windows_; }
+    [[nodiscard]] std::uint32_t tier2_windows() const noexcept { return tier2_windows_; }
+
+private:
+    friend class VisionWindow;
+
+    void require_closed() const {
+        if (pool_.transaction_open() || (kv_arena_ != nullptr && kv_arena_->lease_open())) {
+            throw std::logic_error("a vision overlay window is already open");
+        }
+    }
+
+    void return_loan(std::vector<KVPageRun>& runs) noexcept {
+        if (kv_pages_ == nullptr) { return; }
+        for (const KVPageRun& run : runs) {
+            try {
+                kv_pages_->return_pages(run.begin, run.count);
+            } catch (...) { std::terminate(); }
+        }
+        runs.clear();
+        if (on_change_) { on_change_(); }
+    }
+
+    DeviceContext& device_;
+    EvictableWeightPool& pool_;
+    EvictableKVPool* kv_arena_      = nullptr;
+    DeviceKVPagePool* kv_pages_     = nullptr;
+    std::function<bool()> can_lend_ = nullptr;
+    std::function<void()> on_change_ = nullptr;
+    std::uint32_t tier1_windows_    = 0;
+    std::uint32_t tier2_windows_    = 0;
+};
+
+inline VisionWindow::~VisionWindow() { close(); }
+
+inline VisionWindow::VisionWindow(VisionWindow&& other) noexcept
+    : broker_(other.broker_), tier_(other.tier_), weights_(std::move(other.weights_)),
+      kv_(std::move(other.kv_)), runs_(std::move(other.runs_)) {
+    other.broker_ = nullptr;
+}
+
+inline VisionWindow& VisionWindow::operator=(VisionWindow&& other) noexcept {
+    if (this != &other) {
+        close();
+        broker_       = other.broker_;
+        tier_         = other.tier_;
+        weights_      = std::move(other.weights_);
+        kv_           = std::move(other.kv_);
+        runs_         = std::move(other.runs_);
+        other.broker_ = nullptr;
+    }
+    return *this;
+}
+
+inline void VisionWindow::close() noexcept {
+    if (broker_ == nullptr) { return; }
+    VisionResidencyBroker* const broker = broker_;
+    broker_                             = nullptr;
+    if (tier_ == Tier::KvGranules) {
+        kv_.close();
+        broker->return_loan(runs_);
+    } else {
+        weights_.close();
+    }
+}
+
+// Pinned slots that receive the embeddings of one item each; a session holds one slot for its
+// lifetime, so at most max_concurrency slots are ever needed and no window allocates host memory.
+class PinnedResultPool {
+public:
+    class Handle {
+    public:
+        Handle() noexcept = default;
+        ~Handle() { release(); }
+        Handle(const Handle&)            = delete;
+        Handle& operator=(const Handle&) = delete;
+        Handle(Handle&& other) noexcept
+            : pool_(other.pool_), index_(other.index_), bytes_(other.bytes_) {
+            other.pool_ = nullptr;
+        }
+        Handle& operator=(Handle&& other) noexcept {
+            if (this != &other) {
+                release();
+                pool_       = other.pool_;
+                index_      = other.index_;
+                bytes_      = other.bytes_;
+                other.pool_ = nullptr;
+            }
+            return *this;
+        }
+
+        [[nodiscard]] std::span<std::byte> bytes() const noexcept { return bytes_; }
+
+    private:
+        friend class PinnedResultPool;
+        Handle(PinnedResultPool& pool, std::size_t index, std::span<std::byte> bytes) noexcept
+            : pool_(&pool), index_(index), bytes_(bytes) {}
+        void release() noexcept {
+            if (pool_ != nullptr) {
+                pool_->free_.push_back(index_);
+                pool_ = nullptr;
+            }
+        }
+
+        PinnedResultPool* pool_ = nullptr;
+        std::size_t index_      = 0;
+        std::span<std::byte> bytes_;
+    };
+
+    PinnedResultPool(std::size_t slots, std::size_t slot_bytes) {
+        if (slots == 0 || slot_bytes == 0) {
+            throw std::invalid_argument("pinned vision result pool needs at least one slot");
+        }
+        buffers_.reserve(slots);
+        free_.reserve(slots);
+        for (std::size_t index = 0; index < slots; ++index) {
+            buffers_.push_back(std::make_unique<PinnedHostBuffer>(slot_bytes));
+            free_.push_back(index);
+        }
+    }
+
+    [[nodiscard]] Handle acquire() {
+        if (free_.empty()) {
+            throw std::logic_error("pinned vision result pool has no free slot");
+        }
+        const std::size_t index = free_.back();
+        free_.pop_back();
+        PinnedHostBuffer& buffer = *buffers_[index];
+        return Handle(*this, index,
+                      std::span<std::byte>(static_cast<std::byte*>(buffer.data()), buffer.size()));
+    }
+
+    [[nodiscard]] std::size_t slot_bytes() const noexcept {
+        return buffers_.empty() ? 0 : buffers_.front()->size();
+    }
+
+private:
+    std::vector<std::unique_ptr<PinnedHostBuffer>> buffers_;
+    std::vector<std::size_t> free_;
+};
+
+class VisionWeightStream;
+class VisionOverlaySession;
+
+} // namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule

--- a/src/targets/qwen3_6/impl/runtime/vision_overlay_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_overlay_impl.h
@@ -1,0 +1,376 @@
+#pragma once
+#include "targets/qwen3_6/impl/runtime/instance.h"
+// Qwen3.6 family runtime implementation; instantiated only by exact variants.
+
+#include "core/arena.h"
+#include "core/device.h"
+#include "core/evictable_weight_pool.h"
+#include <ninfer/targets/qwen3_6/vision.h>
+#include "targets/qwen3_6/impl/runtime/vision_context.h"
+#include "targets/qwen3_6/impl/runtime/vision_overlay.h"
+
+#include <chrono>
+#include <optional>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+
+namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule {
+namespace overlay_detail {
+
+using OverlayClock = std::chrono::steady_clock;
+
+inline std::size_t staging_align(std::size_t bytes) {
+    constexpr std::size_t kAlign = 256;
+    return (bytes + kAlign - 1) / kAlign * kAlign;
+}
+
+inline Tensor rebase(Tensor tensor, std::ptrdiff_t delta) {
+    tensor.data = static_cast<std::byte*>(tensor.data) + delta;
+    return tensor;
+}
+
+inline Weight rebase(Weight weight, std::ptrdiff_t delta) {
+    const auto shift = [delta](const void* pointer) -> const void* {
+        return pointer == nullptr
+                   ? nullptr
+                   : static_cast<const void*>(static_cast<const std::byte*>(pointer) + delta);
+    };
+    weight.payload = shift(weight.payload);
+    weight.qdata   = shift(weight.qdata);
+    weight.qhigh   = shift(weight.qhigh);
+    weight.scales  = shift(weight.scales);
+    return weight;
+}
+
+inline qwen3_6::VisionLayerWeights rebase_layer(const qwen3_6::VisionLayerWeights& source,
+                                                std::ptrdiff_t delta) {
+    qwen3_6::VisionLayerWeights out = source;
+    out.qkv                         = rebase(source.qkv, delta);
+    out.qkv_bias                    = rebase(source.qkv_bias, delta);
+    out.output                      = rebase(source.output, delta);
+    out.output_bias                 = rebase(source.output_bias, delta);
+    out.fc1                         = rebase(source.fc1, delta);
+    out.fc1_bias                    = rebase(source.fc1_bias, delta);
+    out.fc2                         = rebase(source.fc2, delta);
+    out.fc2_bias                    = rebase(source.fc2_bias, delta);
+    out.norm1_weight                = rebase(source.norm1_weight, delta);
+    out.norm1_bias                  = rebase(source.norm1_bias, delta);
+    out.norm2_weight                = rebase(source.norm2_weight, delta);
+    out.norm2_bias                  = rebase(source.norm2_bias, delta);
+    return out;
+}
+
+} // namespace overlay_detail
+
+// Workspace plan of one window: the encode scratch of the planned merged-token budget followed by
+// the item handoff, both inside the borrowed extent.
+inline VisionWorkspacePlan window_workspace_plan(const VisionWorkspacePlan& planned) {
+    return VisionContext::plan_workspace(planned.max_merged_tokens, planned.encode_peak_bytes);
+}
+
+// Device bytes one window borrows: the streamed weight staging plus the window workspace.
+inline std::size_t window_bytes(const qwen3_6::VisionOverlayLayout& layout,
+                                const VisionWorkspacePlan& planned) {
+    return overlay_detail::staging_align(layout.staging_bytes) +
+           window_workspace_plan(planned).capacity_bytes;
+}
+
+// Streams the vision tower from the pinned block through borrowed device staging: a fixed prelude
+// region (patch/position embedding), a fixed merger region, and two layer slots refilled on the
+// transfer stream one layer ahead of compute. Synchronization is event-based; the host never
+// blocks between layers.
+class VisionWeightStream {
+public:
+    VisionWeightStream(DeviceContext& device, const qwen3_6::VisionOverlayAssets& assets,
+                       std::byte* staging)
+        : device_(device), assets_(assets) {
+        using overlay_detail::staging_align;
+        const qwen3_6::VisionOverlayLayout& layout = assets.layout;
+        prelude_                                   = staging;
+        merger_                                    = prelude_ + staging_align(layout.prelude.bytes);
+        slot_[0]                                   = merger_ + staging_align(layout.merger.bytes);
+        slot_[1]                                   = slot_[0] + staging_align(layout.slot_bytes);
+        for (cudaEvent_t& event : uploaded_) {
+            CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+        }
+        CUDA_CHECK(cudaEventCreateWithFlags(&prelude_event_, cudaEventDisableTiming));
+        CUDA_CHECK(cudaEventCreateWithFlags(&merger_event_, cudaEventDisableTiming));
+        CUDA_CHECK(cudaEventCreateWithFlags(&compute_fence_, cudaEventDisableTiming));
+
+        const std::byte* block = assets.pinned_block.data();
+        CUDA_CHECK(cudaMemcpyAsync(prelude_, block + layout.prelude.offset, layout.prelude.bytes,
+                                   cudaMemcpyHostToDevice, copy_stream()));
+        CUDA_CHECK(cudaEventRecord(prelude_event_, copy_stream()));
+        CUDA_CHECK(cudaMemcpyAsync(merger_, block + layout.merger.offset, layout.merger.bytes,
+                                   cudaMemcpyHostToDevice, copy_stream()));
+        CUDA_CHECK(cudaEventRecord(merger_event_, copy_stream()));
+        upload_bytes_ = layout.prelude.bytes + layout.merger.bytes;
+        reset(device_.stream);
+    }
+
+    ~VisionWeightStream() {
+        // The window drains both streams before closing; the events are idle here.
+        for (cudaEvent_t event : uploaded_) { (void)cudaEventDestroy(event); }
+        (void)cudaEventDestroy(prelude_event_);
+        (void)cudaEventDestroy(merger_event_);
+        (void)cudaEventDestroy(compute_fence_);
+    }
+
+    VisionWeightStream(const VisionWeightStream&)            = delete;
+    VisionWeightStream& operator=(const VisionWeightStream&) = delete;
+
+    // Rebased view of the host weights: every layer's tensors point at the slot that holds the
+    // layer once arrive(layer) admits it.
+    [[nodiscard]] qwen3_6::VisionWeights window_weights(const qwen3_6::VisionWeights& host) const {
+        using overlay_detail::rebase;
+        using overlay_detail::rebase_layer;
+        const qwen3_6::VisionOverlayLayout& layout = assets_.layout;
+        const std::byte* block                     = assets_.pinned_block.data();
+        const auto delta_to = [block](const std::byte* target, std::size_t source_offset) {
+            return target - (block + source_offset);
+        };
+
+        qwen3_6::VisionWeights out         = host;
+        const std::ptrdiff_t prelude_delta = delta_to(prelude_, layout.prelude.offset);
+        out.common.patch_embedding         = rebase(host.common.patch_embedding, prelude_delta);
+        out.common.patch_embedding_bias = rebase(host.common.patch_embedding_bias, prelude_delta);
+        out.common.position_embedding   = rebase(host.common.position_embedding, prelude_delta);
+        for (std::size_t layer = 0; layer < host.common.layers.size(); ++layer) {
+            const std::ptrdiff_t delta = delta_to(slot_[layer % 2], layout.layers[layer].offset);
+            out.common.layers[layer]   = rebase_layer(host.common.layers[layer], delta);
+        }
+        const std::ptrdiff_t merger_delta = delta_to(merger_, layout.merger.offset);
+        out.common.merger_fc1             = rebase(host.common.merger_fc1, merger_delta);
+        out.common.merger_fc1_bias        = rebase(host.common.merger_fc1_bias, merger_delta);
+        out.common.merger_norm_weight     = rebase(host.common.merger_norm_weight, merger_delta);
+        out.common.merger_norm_bias       = rebase(host.common.merger_norm_bias, merger_delta);
+        out.merger_fc2                    = rebase(host.merger_fc2, merger_delta);
+        out.merger_fc2_bias               = rebase(host.merger_fc2_bias, merger_delta);
+        return out;
+    }
+
+    // Prepare an encode pass: uploads of layers 0 and 1 are issued after everything already
+    // submitted on the compute stream.
+    void reset(cudaStream_t compute) {
+        CUDA_CHECK(cudaEventRecord(compute_fence_, compute));
+        CUDA_CHECK(cudaStreamWaitEvent(copy_stream(), compute_fence_, 0));
+        next_upload_ = 0;
+        upload_next_layer();
+        upload_next_layer();
+    }
+
+    void prelude_ready(cudaStream_t compute) {
+        CUDA_CHECK(cudaStreamWaitEvent(compute, prelude_event_, 0));
+    }
+
+    void merger_ready(cudaStream_t compute) {
+        CUDA_CHECK(cudaStreamWaitEvent(compute, merger_event_, 0));
+    }
+
+    // Called at the top of the encoder loop for `layer`: gates compute on the slot upload, then
+    // refills the slot the previous layer just vacated. Every op of layers below `layer` is
+    // already issued, so the fence orders the refill after them.
+    void arrive(std::uint32_t layer, cudaStream_t compute) {
+        CUDA_CHECK(cudaStreamWaitEvent(compute, uploaded_[layer % 2], 0));
+        if (next_upload_ == layer + 1 &&
+            next_upload_ < static_cast<std::uint32_t>(VisionScheduleConfig::layers)) {
+            CUDA_CHECK(cudaEventRecord(compute_fence_, compute));
+            CUDA_CHECK(cudaStreamWaitEvent(copy_stream(), compute_fence_, 0));
+            upload_next_layer();
+        }
+    }
+
+    [[nodiscard]] std::size_t uploaded_bytes() const noexcept { return upload_bytes_; }
+
+private:
+    [[nodiscard]] cudaStream_t copy_stream() const noexcept { return device_.transfer_stream; }
+
+    void upload_next_layer() {
+        if (next_upload_ >= static_cast<std::uint32_t>(VisionScheduleConfig::layers)) { return; }
+        const std::uint32_t layer                  = next_upload_++;
+        const qwen3_6::VisionOverlayLayout& layout = assets_.layout;
+        CUDA_CHECK(cudaMemcpyAsync(slot_[layer % 2],
+                                   assets_.pinned_block.data() + layout.layers[layer].offset,
+                                   layout.layers[layer].bytes, cudaMemcpyHostToDevice,
+                                   copy_stream()));
+        CUDA_CHECK(cudaEventRecord(uploaded_[layer % 2], copy_stream()));
+        upload_bytes_ += layout.layers[layer].bytes;
+    }
+
+    DeviceContext& device_;
+    const qwen3_6::VisionOverlayAssets& assets_;
+    std::byte* prelude_        = nullptr;
+    std::byte* merger_         = nullptr;
+    std::byte* slot_[2]        = {nullptr, nullptr};
+    cudaEvent_t uploaded_[2]   = {nullptr, nullptr};
+    cudaEvent_t prelude_event_ = nullptr;
+    cudaEvent_t merger_event_  = nullptr;
+    cudaEvent_t compute_fence_ = nullptr;
+    std::uint32_t next_upload_ = 0;
+    std::size_t upload_bytes_  = 0;
+};
+
+// Encodes one vision item per window: borrow the window extent, stream the tower through it, land
+// the merged embeddings in the session's pinned slot, give the memory back. A KV-funded window
+// may stay open across unit boundaries while the encode runs on the vision stream; a weight-tail
+// window is exclusive and lives inside one prefill unit. Only one lane prefills at a time, so at
+// most one window exists even when a submitted one outlives its unit.
+class VisionOverlaySession {
+public:
+    VisionOverlaySession(DeviceContext& device, VisionResidencyBroker& broker,
+                         const qwen3_6::VisionOverlayAssets& assets,
+                         const VisionWorkspacePlan& planned, PinnedResultPool::Handle result)
+        : device_(device), broker_(broker), assets_(assets),
+          window_plan_(window_workspace_plan(planned)), result_(std::move(result)),
+          completion_(device) {
+        if (window_bytes(assets_.layout, planned) > broker_.window_capacity_bytes()) {
+            throw std::logic_error("vision overlay window plan exceeds the pool window capacity");
+        }
+        if (result_.bytes().size() < window_plan_.handoff_capacity_bytes) {
+            throw std::logic_error("pinned vision result slot is smaller than the item handoff");
+        }
+    }
+
+    ~VisionOverlaySession() {
+        if (!pending_) { return; }
+        // The encode still owns the borrowed memory and the staging events. Wait it out before
+        // the weight stream and the window are destroyed; failures here are not recoverable and
+        // must not escape a destructor.
+        (void)cudaStreamSynchronize(encode_stream_);
+        (void)cudaStreamSynchronize(device_.transfer_stream);
+        pending_ = false;
+    }
+
+    VisionOverlaySession(const VisionOverlaySession&)            = delete;
+    VisionOverlaySession& operator=(const VisionOverlaySession&) = delete;
+
+    // Opens a window and enqueues the encode of one item. Tier 1 runs it on the vision stream,
+    // so the decode of other lanes keeps going; tier 2 borrows the text weights and is exclusive.
+    // The window stays open until complete_item().
+    [[nodiscard]] bool submit_item(const VisionItemView& item,
+                                   const qwen3_6::VisionItemControl& control) {
+        using overlay_detail::staging_align;
+        if (pending_) { throw std::logic_error("a vision item is already in flight"); }
+        const std::size_t staging = staging_align(assets_.layout.staging_bytes);
+        // Size the window for this item, not for the planned maximum: fewer chunks to remap and
+        // fewer bytes to restore. The planned window bounds it.
+        const VisionWorkspacePlan item_plan = VisionContext::plan_workspace(
+            control.merged_count,
+            VisionContext::workspace_bytes(control.patch_count, control.merged_count));
+        if (item_plan.capacity_bytes > window_plan_.capacity_bytes) {
+            throw std::invalid_argument("vision item exceeds the overlay window budget");
+        }
+        // Only a KV-funded window may stay open across unit boundaries: a weight-tail window
+        // unmaps the text weights, which would stop every other lane.
+        std::optional<VisionWindow> borrowed =
+            broker_.try_acquire_kv(staging + item_plan.capacity_bytes);
+        if (!borrowed) { return false; }
+        window_start_    = overlay_detail::OverlayClock::now();
+        window_          = std::move(*borrowed);
+        auto* const base = static_cast<std::byte*>(window_.memory().data);
+        const DeviceSpan backing{base + staging, window_.memory().bytes - staging};
+        encode_stream_ = device_.vision_stream;
+        weights_.emplace(device_, assets_, base);
+        const qwen3_6::VisionWeights view = weights_->window_weights(assets_.host.weights);
+        const VisionContext context(device_, view, encode_stream_);
+        Tensor output = VisionContext::bind_output(backing, item_plan, control.merged_count);
+        context.encode(item, output, backing, item_plan, &*weights_);
+        result_bytes_ = output.bytes();
+        if (result_bytes_ > result_.bytes().size()) {
+            throw std::logic_error("vision item embeddings exceed the pinned result slot");
+        }
+        CUDA_CHECK(cudaMemcpyAsync(result_.bytes().data(), output.data, result_bytes_,
+                                   cudaMemcpyDeviceToHost, encode_stream_));
+        completion_.record(encode_stream_);
+        pending_ = true;
+        return true;
+    }
+
+    [[nodiscard]] bool pending() const noexcept { return pending_; }
+    [[nodiscard]] bool item_ready() const { return pending_ && completion_.ready(); }
+
+    // Waits for the submitted item, closes its window and returns the pinned BF16
+    // [out_hidden, merged] embeddings; valid until the next submit_item.
+    [[nodiscard]] std::span<const std::byte> complete_item() {
+        if (!pending_) { throw std::logic_error("no vision item is in flight"); }
+        completion_.synchronize();
+        CUDA_CHECK(cudaStreamSynchronize(device_.transfer_stream));
+        stats_.staged_bytes += weights_->uploaded_bytes();
+        weights_.reset();
+        const bool exclusive       = window_.tier() == VisionWindow::Tier::WeightTail;
+        const double open_seconds  = window_.open_seconds();
+        const std::size_t borrowed = window_.borrowed_bytes();
+        window_.close();
+        pending_ = false;
+        if (broker_.poisoned()) {
+            throw std::runtime_error(
+                "vision overlay window failed to return its memory; the model state is no longer "
+                "trustworthy");
+        }
+        stats_.window_seconds +=
+            std::chrono::duration<double>(overlay_detail::OverlayClock::now() - window_start_)
+                .count();
+        stats_.evict_seconds += open_seconds;
+        stats_.restore_seconds += window_.close_seconds();
+        stats_.evicted_bytes += borrowed;
+        stats_.windows += 1;
+        stats_.exclusive_windows += exclusive ? 1U : 0U;
+        return {result_.bytes().data(), result_bytes_};
+    }
+
+    // Synchronous form: one window, opened and closed inside the caller's prefill unit. Falls
+    // back to the weight tail when free KV cannot fund the window.
+    [[nodiscard]] std::span<const std::byte>
+    encode_item(const VisionItemView& item, const qwen3_6::VisionItemControl& control) {
+        using overlay_detail::staging_align;
+        if (pending_) { throw std::logic_error("a vision item is already in flight"); }
+        const std::size_t staging           = staging_align(assets_.layout.staging_bytes);
+        const VisionWorkspacePlan item_plan = VisionContext::plan_workspace(
+            control.merged_count,
+            VisionContext::workspace_bytes(control.patch_count, control.merged_count));
+        if (item_plan.capacity_bytes > window_plan_.capacity_bytes) {
+            throw std::invalid_argument("vision item exceeds the overlay window budget");
+        }
+        window_start_    = overlay_detail::OverlayClock::now();
+        window_          = broker_.acquire(staging + item_plan.capacity_bytes);
+        auto* const base = static_cast<std::byte*>(window_.memory().data);
+        const DeviceSpan backing{base + staging, window_.memory().bytes - staging};
+        encode_stream_ = window_.tier() == VisionWindow::Tier::KvGranules ? device_.vision_stream
+                                                                         : device_.stream;
+        weights_.emplace(device_, assets_, base);
+        const qwen3_6::VisionWeights view = weights_->window_weights(assets_.host.weights);
+        const VisionContext context(device_, view, encode_stream_);
+        Tensor output = VisionContext::bind_output(backing, item_plan, control.merged_count);
+        context.encode(item, output, backing, item_plan, &*weights_);
+        result_bytes_ = output.bytes();
+        if (result_bytes_ > result_.bytes().size()) {
+            throw std::logic_error("vision item embeddings exceed the pinned result slot");
+        }
+        CUDA_CHECK(cudaMemcpyAsync(result_.bytes().data(), output.data, result_bytes_,
+                                   cudaMemcpyDeviceToHost, encode_stream_));
+        completion_.record(encode_stream_);
+        pending_ = true;
+        return complete_item();
+    }
+
+    [[nodiscard]] const VisionOverlayWindowStats& stats() const noexcept { return stats_; }
+
+private:
+    DeviceContext& device_;
+    VisionResidencyBroker& broker_;
+    const qwen3_6::VisionOverlayAssets& assets_;
+    VisionWorkspacePlan window_plan_;
+    PinnedResultPool::Handle result_;
+    VisionOverlayWindowStats stats_;
+    VisionWindow window_;
+    std::optional<VisionWeightStream> weights_;
+    CudaCompletionEvent completion_;
+    cudaStream_t encode_stream_          = nullptr;
+    std::size_t result_bytes_            = 0;
+    bool pending_                        = false;
+    overlay_detail::OverlayClock::time_point window_start_{};
+};
+
+} // namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule

--- a/src/targets/qwen3_6/impl/runtime/visual_scatter.cpp
+++ b/src/targets/qwen3_6/impl/runtime/visual_scatter.cpp
@@ -21,15 +21,19 @@ void copy_i32(const std::int32_t* source, Tensor& destination, cudaStream_t stre
 
 void scatter_shifted_visual_embeddings(Tensor& input_embeddings, const Tensor& visual_embeddings,
                                        const qwen3_6::MtpVisualOverlap& overlap,
-                                       Tensor& destination_indices, cudaStream_t stream) {
+                                       Tensor& destination_indices, cudaStream_t stream,
+                                       std::size_t source_column_base) {
     if (overlap.empty() || destination_indices.dtype != DType::I32 ||
         destination_indices.ne[0] != static_cast<std::int32_t>(overlap.size())) {
         throw std::invalid_argument("shifted visual scatter has invalid destination indices");
     }
     const auto count = static_cast<std::int32_t>(overlap.size());
     copy_i32(overlap.destination_columns.data(), destination_indices, stream);
-    Tensor embeddings =
-        visual_embeddings.slice(1, static_cast<std::int32_t>(overlap.source_begin), count);
+    if (overlap.source_begin < source_column_base) {
+        throw std::invalid_argument("shifted visual scatter source precedes the staged columns");
+    }
+    Tensor embeddings = visual_embeddings.slice(
+        1, static_cast<std::int32_t>(overlap.source_begin - source_column_base), count);
     ops::scatter(embeddings, destination_indices, input_embeddings, stream);
 }
 

--- a/src/targets/qwen3_6/impl/runtime/visual_scatter.h
+++ b/src/targets/qwen3_6/impl/runtime/visual_scatter.h
@@ -8,14 +8,19 @@
 
 #include <cuda_runtime.h>
 
+#include <cstddef>
+
 #include <cstdint>
 #include <span>
 
 namespace ninfer::targets::qwen3_6::detail {
 
 // Composes the generic scatter Op from the family-provided shifted-window interpretation.
+// source_column_base: item column index held by column 0 of visual_embeddings (nonzero when the
+// caller staged only a window of the item's embeddings).
 void scatter_shifted_visual_embeddings(Tensor& input_embeddings, const Tensor& visual_embeddings,
                                        const qwen3_6::MtpVisualOverlap& overlap,
-                                       Tensor& destination_indices, cudaStream_t stream);
+                                       Tensor& destination_indices, cudaStream_t stream,
+                                       std::size_t source_column_base = 0);
 
 } // namespace ninfer::targets::qwen3_6::detail

--- a/src/targets/qwen3_6/impl/runtime/workspace_recipe.h
+++ b/src/targets/qwen3_6/impl/runtime/workspace_recipe.h
@@ -26,11 +26,15 @@ struct TextPrefillRoots {
     Tensor rope_positions;
     Tensor residual;
     Tensor scatter_indices;
+    // Overlay vision only: per-chunk device staging for the visual embeddings uploaded from the
+    // pinned window result, [hidden, scatter_tokens + 1].
+    Tensor visual_embeddings;
 };
 
 template <class Config, class Allocator>
 TextPrefillRoots text_prefill_roots(Allocator& allocator, std::int32_t tokens,
-                                    std::int32_t rope_axes, std::int32_t scatter_tokens) {
+                                    std::int32_t rope_axes, std::int32_t scatter_tokens,
+                                    bool overlay_staging = false) {
     TextPrefillRoots out;
     out.ids       = vector(allocator, DType::I32, tokens);
     out.positions = vector(allocator, DType::I32, tokens);
@@ -38,6 +42,12 @@ TextPrefillRoots text_prefill_roots(Allocator& allocator, std::int32_t tokens,
     out.residual = matrix(allocator, DType::BF16, Config::hidden, tokens);
     if (scatter_tokens != 0) {
         out.scatter_indices = vector(allocator, DType::I32, scatter_tokens);
+        if (overlay_staging) {
+            // One extra column: the shifted MTP input of the chunk's last visual token is the next
+            // visual column, which may belong to the following chunk.
+            out.visual_embeddings =
+                matrix(allocator, DType::BF16, Config::hidden, scatter_tokens + 1);
+        }
     }
     return out;
 }

--- a/src/targets/qwen3_6/impl/vision/bindings.cpp
+++ b/src/targets/qwen3_6/impl/vision/bindings.cpp
@@ -3,13 +3,86 @@
 #include "artifact/materializer.h"
 #include "artifact/typed_binding.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
+#include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 
 namespace ninfer::targets::qwen3_6 {
+namespace {
+
+constexpr std::size_t kStagingAlignment = 256;
+
+std::size_t staging_align(std::size_t bytes) {
+    return (bytes + kStagingAlignment - 1) / kStagingAlignment * kStagingAlignment;
+}
+
+// Pinned extent covering exactly the listed objects: every object must be pinned, and no other
+// pinned object may fall inside the covered range.
+PinnedRange pinned_group_range(const artifact::MaterializationPlan& plan,
+                               std::span<const artifact::ObjectHandle> group) {
+    std::size_t begin = SIZE_MAX;
+    std::size_t end   = 0;
+    for (const artifact::ObjectHandle handle : group) {
+        const auto it = std::find_if(plan.pinned_objects.begin(), plan.pinned_objects.end(),
+                                     [&](const artifact::PinnedMaterialization& placement) {
+                                         return placement.object.index == handle.index;
+                                     });
+        if (it == plan.pinned_objects.end()) {
+            throw std::logic_error("vision overlay group tensor is not host-pinned");
+        }
+        begin = std::min(begin, static_cast<std::size_t>(it->offset));
+        end   = std::max(end, static_cast<std::size_t>(it->offset + it->bytes));
+    }
+    if (begin == SIZE_MAX || end <= begin) {
+        throw std::logic_error("vision overlay group is empty");
+    }
+    for (const artifact::PinnedMaterialization& placement : plan.pinned_objects) {
+        const bool member = std::any_of(group.begin(), group.end(), [&](artifact::ObjectHandle h) {
+            return h.index == placement.object.index;
+        });
+        const std::size_t object_begin = placement.offset;
+        const std::size_t object_end   = placement.offset + placement.bytes;
+        if (!member && object_begin < end && object_end > begin) {
+            throw std::logic_error("vision overlay group interleaves with a foreign pinned tensor");
+        }
+    }
+    return PinnedRange{begin, end - begin};
+}
+
+} // namespace
+
+VisionOverlayLayout compute_vision_overlay_layout(const VisionBackbonePlan& backbone,
+                                                  const VisionMergerInputPlan& merger_input,
+                                                  artifact::ObjectHandle merger_fc2,
+                                                  artifact::ObjectHandle merger_fc2_bias,
+                                                  const VisionMergerNormPlan& merger_norm,
+                                                  const artifact::MaterializationPlan& plan) {
+    VisionOverlayLayout out;
+    const std::array<artifact::ObjectHandle, 3> prelude = {
+        backbone.patch_embedding, backbone.patch_embedding_bias, backbone.position_embedding};
+    out.prelude = pinned_group_range(plan, prelude);
+    for (std::size_t layer = 0; layer < backbone.layers.size(); ++layer) {
+        const VisionLayerPlan& source                        = backbone.layers[layer];
+        const std::array<artifact::ObjectHandle, 12> handles = {
+            source.qkv,          source.qkv_bias,   source.output,       source.output_bias,
+            source.fc1,          source.fc1_bias,   source.fc2,          source.fc2_bias,
+            source.norm1_weight, source.norm1_bias, source.norm2_weight, source.norm2_bias};
+        out.layers[layer] = pinned_group_range(plan, handles);
+        out.slot_bytes    = std::max(out.slot_bytes, out.layers[layer].bytes);
+    }
+    const std::array<artifact::ObjectHandle, 6> merger = {
+        merger_input.fc1, merger_input.fc1_bias, merger_fc2,
+        merger_fc2_bias,  merger_norm.weight,    merger_norm.bias};
+    out.merger        = pinned_group_range(plan, merger);
+    out.staging_bytes = staging_align(out.prelude.bytes) + staging_align(out.merger.bytes) +
+                        2 * staging_align(out.slot_bytes);
+    return out;
+}
 
 VisionBackbonePlan bind_vision_backbone(artifact::Binder& binder,
                                         artifact::TensorPlacement placement) {

--- a/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
+++ b/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
@@ -50,6 +50,9 @@ public:
     LoadPlan& operator=(const LoadPlan&) = delete;
 
     [[nodiscard]] const artifact::MaterializationPlan& materialization() const;
+    // Device staging bytes one overlay window needs for streamed vision weights; 0 when the plan
+    // was built for resident vision.
+    [[nodiscard]] std::size_t overlay_staging_bytes() const;
 
 private:
     class Impl;

--- a/src/targets/qwen3_6_27b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.cpp
@@ -1,6 +1,7 @@
 #include "targets/qwen3_6_27b/impl/load/bindings.h"
 
 #include "artifact/typed_binding.h"
+#include "core/evictable_weight_pool.h"
 
 #include <algorithm>
 #include <array>
@@ -65,13 +66,24 @@ void require_positive_finite(std::uint32_t bits, std::string_view label) {
 }
 
 WeightPlan bind_weight(artifact::Binder& binder, std::string_view name, NumericFormat format,
-                       std::initializer_list<std::uint64_t> shape) {
+                       std::initializer_list<std::uint64_t> shape,
+                       std::uint32_t evict_rank = 0) {
     if (format == NumericFormat::NVFP4) {
         throw std::logic_error("NVFP4 weight requires a paired input divisor");
     }
-    return WeightPlan{.object = artifact::bind_device_tensor(binder, name, format, shape),
+    return WeightPlan{.object = artifact::bind_tensor(binder, name, format, shape,
+                                                      artifact::TensorPlacement::Device,
+                                                      evict_rank),
                       .format = format};
 }
+
+// Overlay eviction ladder: higher ranks sit at the arena end and are borrowed first. The four
+// endpoint groups provide about 3.3 GiB of evictable tail, far beyond any window, so decoder
+// blocks stay unranked.
+constexpr std::uint32_t kEvictRankMtp       = 400;
+constexpr std::uint32_t kEvictRankDraftHead = 500;
+constexpr std::uint32_t kEvictRankEmbedding = 600;
+constexpr std::uint32_t kEvictRankLmHead    = 700;
 
 WeightPlan bind_nvfp4_weight(artifact::Binder& binder, std::string_view name, std::int32_t rows,
                              std::int32_t columns, std::string_view input_divisor_name) {
@@ -418,8 +430,10 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
     out.features     = features;
 
     const NumericFormat vocabulary_format = endpoint_format(weights_profile);
+    const bool overlay  = features.overlay_vision();
     out.token_embedding =
-        bind_weight(binder, "text/token_embedding", vocabulary_format, {248320, 5120});
+        bind_weight(binder, "text/token_embedding", vocabulary_format, {248320, 5120},
+                    overlay ? kEvictRankEmbedding : 0);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
     case WeightsProfile::Qwen38GroupwiseInt:
@@ -436,12 +450,14 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
     }
     out.final_norm =
         artifact::bind_device_tensor(binder, "text/final_norm", NumericFormat::BF16, {5120});
-    out.output_head = bind_weight(binder, "text/output_head", vocabulary_format, {248320, 5120});
+    out.output_head = bind_weight(binder, "text/output_head", vocabulary_format, {248320, 5120},
+                                  overlay ? kEvictRankLmHead : 0);
     const artifact::TensorPlacement proposal_placement =
         features.optimized_proposal() ? artifact::TensorPlacement::Device
                                       : artifact::TensorPlacement::ValidateOnly;
     out.draft_head = artifact::bind_tensor(binder, "text/draft_head", NumericFormat::Q4G64_F16S,
-                                           {131072, 5120}, proposal_placement);
+                                           {131072, 5120}, proposal_placement,
+                                           overlay ? kEvictRankDraftHead : 0);
     out.draft_head_token_ids = artifact::bind_tensor(
         binder, "text/draft_head_token_ids", NumericFormat::I32, {131072}, proposal_placement);
     validate_draft_ids(binder, out.draft_head_token_ids);
@@ -451,7 +467,8 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
                                                         : artifact::TensorPlacement::ValidateOnly;
     const auto bind_mtp                           = [&](std::string_view name, NumericFormat format,
                               std::initializer_list<std::uint64_t> shape) {
-        return artifact::bind_tensor(binder, name, format, shape, mtp_placement);
+        return artifact::bind_tensor(binder, name, format, shape, mtp_placement,
+                                     overlay ? kEvictRankMtp : 0);
     };
     out.mtp.input_projection =
         bind_mtp("mtp/input_projection", NumericFormat::W8G32_F16S, {5120, 10240});
@@ -475,8 +492,9 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
     out.mtp.final_norm = bind_mtp("mtp/final_norm", NumericFormat::BF16, {5120});
 
     const artifact::TensorPlacement vision_placement =
-        features.vision ? artifact::TensorPlacement::Device
-                        : artifact::TensorPlacement::ValidateOnly;
+        overlay           ? artifact::TensorPlacement::HostPinned
+        : features.vision ? artifact::TensorPlacement::Device
+                          : artifact::TensorPlacement::ValidateOnly;
     out.vision_backbone     = qwen3_6::bind_vision_backbone(binder, vision_placement);
     out.vision_merger_input = qwen3_6::bind_vision_merger_input(binder, vision_placement);
     out.vision_merger_fc2   = artifact::bind_tensor(
@@ -485,7 +503,13 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
         binder, "vision/merger/fc2_bias", NumericFormat::BF16, {5120}, vision_placement);
     out.vision_merger_norm = qwen3_6::bind_vision_merger_norm(binder, vision_placement);
 
-    load_plan.materialization = binder.finish();
+    load_plan.materialization =
+        binder.finish(overlay ? ninfer::EvictableWeightPool::kChunkBytes : 1);
+    if (overlay) {
+        out.vision_overlay = qwen3_6::compute_vision_overlay_layout(
+            out.vision_backbone, out.vision_merger_input, out.vision_merger_fc2,
+            out.vision_merger_fc2_bias, out.vision_merger_norm, load_plan.materialization);
+    }
     return load_plan;
 }
 
@@ -583,13 +607,30 @@ LoadedModelData::LoadedModelData(BindingPlan plan, artifact::MaterializedArtifac
     }
 
     if (plan.features.vision) {
-        auto& vision  = runtime.vision.emplace();
+        qwen3_6::VisionWeights vision;
         vision.common = qwen3_6::materialize_vision_common(
             backing, plan.vision_backbone, plan.vision_merger_input, plan.vision_merger_norm);
         vision.merger_fc2      = artifact::materialized_weight(backing, plan.vision_merger_fc2,
                                                                NumericFormat::W8G32_F16S, 5120, 4608);
         vision.merger_fc2_bias = artifact::materialized_tensor(backing, plan.vision_merger_fc2_bias,
                                                                NumericFormat::BF16, {5120});
+        if (plan.features.overlay_vision()) {
+            // The tower lives in pinned host memory; publish it only as host weights so no device
+            // VisionContext can be bound over it.
+            if (!plan.vision_overlay || backing.eviction_pool() == nullptr ||
+                backing.pinned_block().empty()) {
+                throw std::logic_error(
+                    "overlay vision requires a pool-backed pinned materialization");
+            }
+            auto& overlay                = runtime.vision_overlay.emplace();
+            overlay.pool                 = backing.eviction_pool();
+            overlay.pinned_block         = backing.pinned_block();
+            overlay.host.weights         = vision;
+            overlay.layout               = *plan.vision_overlay;
+            overlay.window_capacity_bytes = backing.eviction_pool()->window_capacity_bytes();
+        } else {
+            runtime.vision = vision;
+        }
     }
 }
 

--- a/src/targets/qwen3_6_27b/impl/load/bindings.h
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <variant>
 
@@ -121,6 +122,7 @@ struct BindingPlan {
     artifact::ObjectHandle vision_merger_fc2;
     artifact::ObjectHandle vision_merger_fc2_bias;
     qwen3_6::VisionMergerNormPlan vision_merger_norm;
+    std::optional<qwen3_6::VisionOverlayLayout> vision_overlay;
 };
 
 struct ArtifactLoadPlan {

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -26,6 +26,11 @@ LoadPlan::LoadPlan(LoadPlan&&) noexcept            = default;
 LoadPlan& LoadPlan::operator=(LoadPlan&&) noexcept = default;
 LoadPlan::~LoadPlan()                              = default;
 
+std::size_t LoadPlan::overlay_staging_bytes() const {
+    if (impl_ == nullptr || !impl_->plan.bindings.vision_overlay) { return 0; }
+    return impl_->plan.bindings.vision_overlay->staging_bytes;
+}
+
 const artifact::MaterializationPlan& LoadPlan::materialization() const {
     if (impl_ == nullptr) { throw std::logic_error("target load plan is empty"); }
     return impl_->plan.materialization;
@@ -126,6 +131,7 @@ Package::Frontend Package::make_frontend(const LoadedModel& model, const EngineO
             .media_live_bytes              = options.media_live_bytes,
             .media_preprocess_threads      = options.media_preprocess_threads,
             .max_cache_markers_per_request = *options.context_cache.max_cache_markers_per_request,
+            .vision_max_merged_tokens = options.vision_max_merged_tokens,
         });
 }
 

--- a/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
+++ b/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
@@ -47,6 +47,9 @@ public:
     LoadPlan& operator=(const LoadPlan&) = delete;
 
     [[nodiscard]] const artifact::MaterializationPlan& materialization() const;
+    // Device staging bytes one overlay window needs for streamed vision weights; 0 when the plan
+    // was built for resident vision.
+    [[nodiscard]] std::size_t overlay_staging_bytes() const;
 
 private:
     class Impl;

--- a/src/targets/qwen3_6_35b_a3b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/load/bindings.cpp
@@ -1,6 +1,7 @@
 #include "targets/qwen3_6_35b_a3b/impl/load/bindings.h"
 
 #include "artifact/typed_binding.h"
+#include "core/evictable_weight_pool.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -94,13 +95,23 @@ void validate_draft_ids(const artifact::Binder& binder, artifact::ObjectHandle h
 
 } // namespace
 
+// Overlay eviction ladder, shared semantics with the 27B target: higher ranks sit at the arena end
+// and are borrowed first.
+constexpr std::uint32_t kEvictRankMtp       = 400;
+constexpr std::uint32_t kEvictRankDraftHead = 500;
+constexpr std::uint32_t kEvictRankEmbedding = 600;
+constexpr std::uint32_t kEvictRankLmHead    = 700;
+
 ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeatures features) {
     ArtifactLoadPlan load_plan;
     BindingPlan& out    = load_plan.bindings;
     out.frontend        = qwen3_6::bind_frontend_resources(binder);
     out.features        = features;
-    out.token_embedding = artifact::bind_device_tensor(binder, "text/token_embedding",
-                                                       NumericFormat::W8G32_F16S, {248320, 2048});
+    const bool overlay  = features.overlay_vision();
+    out.token_embedding = artifact::bind_tensor(binder, "text/token_embedding",
+                                                NumericFormat::W8G32_F16S, {248320, 2048},
+                                                artifact::TensorPlacement::Device,
+                                                overlay ? kEvictRankEmbedding : 0);
 
     for (std::size_t layer = 0; layer < kTextLayers; ++layer) {
         TextLayerPlan& target    = out.text_layers[layer];
@@ -142,13 +153,15 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
 
     out.final_norm =
         artifact::bind_device_tensor(binder, "text/final_norm", NumericFormat::BF16, {2048});
-    out.output_head = artifact::bind_device_tensor(binder, "text/output_head",
-                                                   NumericFormat::Q6G64_F16S, {248320, 2048});
+    out.output_head = artifact::bind_tensor(binder, "text/output_head", NumericFormat::Q6G64_F16S,
+                                            {248320, 2048}, artifact::TensorPlacement::Device,
+                                            overlay ? kEvictRankLmHead : 0);
     const artifact::TensorPlacement proposal_placement =
         features.optimized_proposal() ? artifact::TensorPlacement::Device
                                       : artifact::TensorPlacement::ValidateOnly;
     out.draft_head = artifact::bind_tensor(binder, "text/draft_head", NumericFormat::Q4G64_F16S,
-                                           {131072, 2048}, proposal_placement);
+                                           {131072, 2048}, proposal_placement,
+                                           overlay ? kEvictRankDraftHead : 0);
     out.draft_head_token_ids = artifact::bind_tensor(
         binder, "text/draft_head_token_ids", NumericFormat::I32, {131072}, proposal_placement);
     validate_draft_ids(binder, out.draft_head_token_ids);
@@ -158,7 +171,8 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
                                                         : artifact::TensorPlacement::ValidateOnly;
     const auto bind_mtp                           = [&](std::string_view name, NumericFormat format,
                               std::initializer_list<std::uint64_t> shape) {
-        return artifact::bind_tensor(binder, name, format, shape, mtp_placement);
+        return artifact::bind_tensor(binder, name, format, shape, mtp_placement,
+                                     overlay ? kEvictRankMtp : 0);
     };
     out.mtp.input_projection =
         bind_mtp("mtp/input_projection", NumericFormat::W8G32_F16S, {2048, 4096});
@@ -180,8 +194,9 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
     out.mtp.final_norm = bind_mtp("mtp/final_norm", NumericFormat::BF16, {2048});
 
     const artifact::TensorPlacement vision_placement =
-        features.vision ? artifact::TensorPlacement::Device
-                        : artifact::TensorPlacement::ValidateOnly;
+        overlay           ? artifact::TensorPlacement::HostPinned
+        : features.vision ? artifact::TensorPlacement::Device
+                          : artifact::TensorPlacement::ValidateOnly;
     out.vision_backbone     = qwen3_6::bind_vision_backbone(binder, vision_placement);
     out.vision_merger_input = qwen3_6::bind_vision_merger_input(binder, vision_placement);
     out.vision_merger_fc2   = artifact::bind_tensor(
@@ -224,7 +239,13 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
         out.dflash.final_norm = bind_dflash("dflash/final_norm", NumericFormat::BF16, {2048});
     }
 
-    load_plan.materialization = binder.finish();
+    load_plan.materialization =
+        binder.finish(overlay ? ninfer::EvictableWeightPool::kChunkBytes : 1);
+    if (overlay) {
+        out.vision_overlay = qwen3_6::compute_vision_overlay_layout(
+            out.vision_backbone, out.vision_merger_input, out.vision_merger_fc2,
+            out.vision_merger_fc2_bias, out.vision_merger_norm, load_plan.materialization);
+    }
     return load_plan;
 }
 
@@ -332,13 +353,28 @@ LoadedModelData::LoadedModelData(BindingPlan plan, artifact::MaterializedArtifac
     }
 
     if (plan.features.vision) {
-        auto& vision  = runtime.vision.emplace();
+        qwen3_6::VisionWeights vision;
         vision.common = qwen3_6::materialize_vision_common(
             backing, plan.vision_backbone, plan.vision_merger_input, plan.vision_merger_norm);
         vision.merger_fc2      = artifact::materialized_weight(backing, plan.vision_merger_fc2,
                                                                NumericFormat::W8G32_F16S, 2048, 4608);
         vision.merger_fc2_bias = artifact::materialized_tensor(backing, plan.vision_merger_fc2_bias,
                                                                NumericFormat::BF16, {2048});
+        if (plan.features.overlay_vision()) {
+            if (!plan.vision_overlay || backing.eviction_pool() == nullptr ||
+                backing.pinned_block().empty()) {
+                throw std::logic_error(
+                    "overlay vision requires a pool-backed pinned materialization");
+            }
+            auto& overlay                = runtime.vision_overlay.emplace();
+            overlay.pool                 = backing.eviction_pool();
+            overlay.pinned_block         = backing.pinned_block();
+            overlay.host.weights         = vision;
+            overlay.layout               = *plan.vision_overlay;
+            overlay.window_capacity_bytes = backing.eviction_pool()->window_capacity_bytes();
+        } else {
+            runtime.vision = vision;
+        }
     }
 
     if (plan.features.dflash()) {

--- a/src/targets/qwen3_6_35b_a3b/impl/load/bindings.h
+++ b/src/targets/qwen3_6_35b_a3b/impl/load/bindings.h
@@ -101,6 +101,7 @@ struct BindingPlan {
     artifact::ObjectHandle vision_merger_fc2;
     artifact::ObjectHandle vision_merger_fc2_bias;
     qwen3_6::VisionMergerNormPlan vision_merger_norm;
+    std::optional<qwen3_6::VisionOverlayLayout> vision_overlay;
     DFlashPlan dflash;
 };
 

--- a/src/targets/qwen3_6_35b_a3b/impl/package.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/package.cpp
@@ -26,6 +26,11 @@ LoadPlan::LoadPlan(LoadPlan&&) noexcept            = default;
 LoadPlan& LoadPlan::operator=(LoadPlan&&) noexcept = default;
 LoadPlan::~LoadPlan()                              = default;
 
+std::size_t LoadPlan::overlay_staging_bytes() const {
+    if (impl_ == nullptr || !impl_->plan.bindings.vision_overlay) { return 0; }
+    return impl_->plan.bindings.vision_overlay->staging_bytes;
+}
+
 const artifact::MaterializationPlan& LoadPlan::materialization() const {
     if (impl_ == nullptr) { throw std::logic_error("target load plan is empty"); }
     return impl_->plan.materialization;
@@ -98,6 +103,7 @@ Package::Frontend Package::make_frontend(const LoadedModel& model, const EngineO
             .media_live_bytes              = options.media_live_bytes,
             .media_preprocess_threads      = options.media_preprocess_threads,
             .max_cache_markers_per_request = *options.context_cache.max_cache_markers_per_request,
+            .vision_max_merged_tokens = options.vision_max_merged_tokens,
         });
 }
 

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -4,6 +4,7 @@
 #include "artifact/materializer.h"
 #include "artifact/reader.h"
 #include "core/device.h"
+#include "core/evictable_weight_pool.h"
 #include "runtime/engine/kv_capacity.h"
 #include "runtime/engine/context_cost.h"
 
@@ -111,10 +112,39 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
         runtime_bytes_after_planned_weights(load_plan.materialization().device_capacity_bytes);
     (void)runtime::resolve_kv_capacity(options.kv_capacity, curve, preflight_runtime_bytes);
 
+    const bool overlay_vision =
+        options.enable_vision && options.vision_residency == VisionResidency::Overlay;
+    std::unique_ptr<EvictableWeightPool> pool;
+    std::size_t overlay_window_bytes = 0;
+    if (overlay_vision) {
+        const std::size_t staging = load_plan.overlay_staging_bytes();
+        if (staging == 0) {
+            throw std::invalid_argument(
+                "the selected target does not support --vision-residency overlay");
+        }
+        if (!EvictableWeightPool::supported(device)) {
+            throw std::invalid_argument(
+                "--vision-residency overlay requires CUDA virtual memory management support");
+        }
+        overlay_window_bytes = staging + sequence_planner.vision_window_bytes();
+        pool                 = std::make_unique<EvictableWeightPool>(
+            device, EvictableWeightPool::Config{
+                        .arena_bytes           = load_plan.materialization().device_capacity_bytes,
+                        .evictable_tail_bytes  = load_plan.materialization().evictable_tail_bytes,
+                        .window_capacity_bytes = overlay_window_bytes,
+                    });
+        overlay_window_bytes = pool->window_capacity_bytes();
+    }
     auto progress     = artifact_progress(options.load_progress);
     auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
-                                              progress.callback ? &progress : nullptr);
+                                              progress.callback ? &progress : nullptr,
+                                              std::move(pool));
     const artifact::MaterializationStats stats = materialized.stats();
+    if (overlay_vision) {
+        // The mirror must see the final weight bytes: the upload stream is drained by
+        // materialize(), and no tail chunk changes afterwards.
+        materialized.eviction_pool()->capture_window_mirror(device.transfer_stream);
+    }
 
     auto model = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));
     device.synchronize();
@@ -140,6 +170,8 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
     summary.artifact_bytes_read  = stats.file_bytes;
     summary.host_to_device_bytes = stats.h2d_bytes;
     summary.peak_staging_bytes   = stats.peak_staging_bytes;
+    summary.pinned_weight_bytes  = stats.pinned_weight_bytes;
+    summary.overlay_window_bytes = overlay_window_bytes;
     summary.tensor_count         = stats.tensor_count;
     summary.resource_count       = stats.resource_count;
     summary.context_cost         = context_cost.summary;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,11 @@ ninfer_add_test(ninfer_admission_policy_test SOURCES test_admission_policy.cpp)
 ninfer_add_test(ninfer_context_cost_test SOURCES test_context_cost.cpp)
 ninfer_add_test(ninfer_resource_manager_test SOURCES test_resource_manager.cpp)
 ninfer_add_test(ninfer_kv_capacity_test SOURCES test_kv_capacity.cpp)
+ninfer_add_test(ninfer_vmm_graph_remap_test SOURCES test_vmm_graph_remap.cu)
+target_link_libraries(ninfer_vmm_graph_remap_test PRIVATE CUDA::cuda_driver)
+ninfer_add_test(ninfer_evictable_kv_pool_test SOURCES test_evictable_kv_pool.cu)
+target_link_libraries(ninfer_evictable_kv_pool_test PRIVATE CUDA::cuda_driver)
+ninfer_add_test(ninfer_evictable_weight_pool_test SOURCES test_evictable_weight_pool.cu)
 ninfer_add_test(ninfer_sampling_defaults_test
   SOURCES test_sampling_defaults.cpp
   LIBRARIES ninfer_engine ninfer_core)

--- a/tests/test_artifact_materialization.cpp
+++ b/tests/test_artifact_materialization.cpp
@@ -4,6 +4,7 @@
 #include "artifact/typed_binding.h"
 #include "artifact_fixture.h"
 #include "core/device.h"
+#include "core/evictable_weight_pool.h"
 
 #include <cuda_runtime.h>
 
@@ -12,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 
 namespace {
@@ -196,6 +198,118 @@ int main() {
         require(materialized.device_arena().capacity() == plan.device_capacity_bytes &&
                     materialized.device_arena().used() == plan.device_capacity_bytes,
                 "materialized tensor does not own the planned device backing");
+        // Overlay plan mechanics: an evict-ranked tensor lands in a chunk-aligned arena tail
+        // backed by the eviction pool, a HostPinned tensor lands in the pinned block, and a
+        // transaction preserves every byte of the borrowed chunk.
+        if (ninfer::EvictableWeightPool::supported(device)) {
+            constexpr std::size_t kChunk = ninfer::EvictableWeightPool::kChunkBytes;
+            ninfer::artifact::Binder overlay_binder(reader);
+            const auto overlay_resource = overlay_binder.require_resource(
+                "frontend/test.json", ninfer::artifact::ResourceEncoding::RawBytesV1);
+            overlay_binder.retain_on_host(overlay_resource);
+            const auto resident =
+                overlay_binder.require_tensor("weights/test", ninfer::artifact::NumericFormat::BF16,
+                                              ninfer::artifact::StorageLayout::ContiguousLeV1,
+                                              tensor_shape);
+            overlay_binder.materialize_on_device(resident);
+            const auto evictable = overlay_binder.require_tensor(
+                "weights/second", ninfer::artifact::NumericFormat::BF16,
+                ninfer::artifact::StorageLayout::ContiguousLeV1, second_shape);
+            overlay_binder.materialize_on_device(evictable, /*evict_rank=*/700);
+            const auto overlay_fp8 = overlay_binder.require_tensor(
+                "weights/fp8", ninfer::artifact::NumericFormat::FP8_E4M3FN_ROW_BF16S,
+                ninfer::artifact::StorageLayout::RowScaleV1, fp8_shape);
+            overlay_binder.validate_only(overlay_fp8);
+            const ninfer::artifact::MaterializationPlan overlay_plan =
+                overlay_binder.finish(kChunk);
+            require(overlay_plan.evictable_tail_offset == kChunk &&
+                        overlay_plan.evictable_tail_bytes == kSecondTensor.size() &&
+                        overlay_plan.device_objects.back().offset ==
+                            overlay_plan.evictable_tail_offset &&
+                        overlay_plan.device_objects.back().alignment ==
+                            overlay_plan.device_objects.front().alignment &&
+                        overlay_plan.device_capacity_bytes == kChunk + kSecondTensor.size(),
+                    "evict-ranked tensor was not planned into a chunk-aligned arena tail");
+
+            auto pool = std::make_unique<ninfer::EvictableWeightPool>(
+                device, ninfer::EvictableWeightPool::Config{
+                            .arena_bytes           = overlay_plan.device_capacity_bytes,
+                            .evictable_tail_bytes  = overlay_plan.evictable_tail_bytes,
+                            .window_capacity_bytes = kChunk,
+                        });
+            auto overlay_materialized = ninfer::artifact::materialize(
+                reader, overlay_plan, device, nullptr, std::move(pool));
+            ninfer::EvictableWeightPool* live_pool = overlay_materialized.eviction_pool();
+            require(live_pool != nullptr, "pool-backed materialization dropped the pool");
+            require(overlay_materialized.device_arena().used() ==
+                        overlay_plan.device_capacity_bytes,
+                    "pool-backed arena does not account the planned capacity");
+            live_pool->capture_window_mirror(device.transfer_stream);
+
+            void* evictable_home = overlay_materialized.device_data(evictable);
+            {
+                auto transaction = live_pool->evict(kChunk, device.stream);
+                require(transaction.leased().bytes == kChunk,
+                        "window transaction mapped an unexpected extent");
+                CUDA_CHECK(cudaMemsetAsync(transaction.leased().data, 0x5A,
+                                           transaction.leased().bytes, device.stream));
+                CUDA_CHECK(cudaStreamSynchronize(device.stream));
+                transaction.close();
+                require(!live_pool->poisoned(), "window transaction poisoned the pool");
+            }
+            require(overlay_materialized.device_data(evictable) == evictable_home,
+                    "evictable tensor address changed across the overlay transaction");
+            std::array<std::byte, kSecondTensor.size()> roundtrip{};
+            CUDA_CHECK(cudaMemcpy(roundtrip.data(), evictable_home, roundtrip.size(),
+                                  cudaMemcpyDeviceToHost));
+            require(roundtrip == kSecondTensor,
+                    "evictable tensor bytes were not restored from the mirror");
+        } else {
+            std::cout << "note: VMM unsupported, overlay plan mechanics not exercised\n";
+        }
+
+        {
+            // HostPinned placement: payload lands in the pinned block, never on device.
+            ninfer::artifact::Binder pinned_binder(reader);
+            const auto pinned_resource = pinned_binder.require_resource(
+                "frontend/test.json", ninfer::artifact::ResourceEncoding::RawBytesV1);
+            pinned_binder.retain_on_host(pinned_resource);
+            const auto device_tensor =
+                pinned_binder.require_tensor("weights/test", ninfer::artifact::NumericFormat::BF16,
+                                             ninfer::artifact::StorageLayout::ContiguousLeV1,
+                                             tensor_shape);
+            pinned_binder.materialize_on_device(device_tensor);
+            const auto pinned_tensor = pinned_binder.require_tensor(
+                "weights/second", ninfer::artifact::NumericFormat::BF16,
+                ninfer::artifact::StorageLayout::ContiguousLeV1, second_shape);
+            pinned_binder.materialize_on_host_pinned(pinned_tensor);
+            const auto pinned_fp8 = pinned_binder.require_tensor(
+                "weights/fp8", ninfer::artifact::NumericFormat::FP8_E4M3FN_ROW_BF16S,
+                ninfer::artifact::StorageLayout::RowScaleV1, fp8_shape);
+            pinned_binder.validate_only(pinned_fp8);
+            const ninfer::artifact::MaterializationPlan pinned_plan = pinned_binder.finish();
+            require(pinned_plan.pinned_objects.size() == 1 &&
+                        pinned_plan.pinned_capacity_bytes == kSecondTensor.size() &&
+                        pinned_plan.device_capacity_bytes == kTensor.size(),
+                    "pinned placement was not planned into the pinned block");
+
+            auto pinned_materialized =
+                ninfer::artifact::materialize(reader, pinned_plan, device);
+            require(pinned_materialized.is_host_pinned(pinned_tensor) &&
+                        !pinned_materialized.is_host_pinned(device_tensor),
+                    "pinned residency is not reported per object");
+            const auto block = pinned_materialized.pinned_block();
+            require(block.size() == kSecondTensor.size() &&
+                        std::equal(block.begin(), block.end(), kSecondTensor.begin(),
+                                   kSecondTensor.end()),
+                    "pinned block content differs from the artifact payload");
+            require(pinned_materialized.storage_data(pinned_tensor) ==
+                        const_cast<std::byte*>(block.data()) +
+                            pinned_materialized.pinned_offset(pinned_tensor),
+                    "pinned tensor storage pointer is outside the pinned block");
+            require(pinned_materialized.stats().pinned_weight_bytes == kSecondTensor.size(),
+                    "pinned weight bytes are not accounted");
+        }
         return 0;
     } catch (const std::exception& error) {
         std::cerr << error.what() << '\n';

--- a/tests/test_evictable_kv_pool.cu
+++ b/tests/test_evictable_kv_pool.cu
@@ -1,0 +1,248 @@
+// Lifetime and integrity qualification for the VMM-backed KV arena: stable home addresses across
+// leases, granules handed out contiguously at the overlay range, resident bytes untouched by a
+// lease, and rejection of invalid leases.
+
+#include "core/arena.h"
+#include "core/device.h"
+#include "core/evictable_kv_pool.h"
+#include "core/kv_loan.h"
+#include "core/layout.h"
+#include "core/paged_kv_cache.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <optional>
+#include <vector>
+
+namespace {
+
+bool cuda_unavailable(cudaError_t err) {
+    return err == cudaErrorNoDevice || err == cudaErrorInsufficientDriver;
+}
+
+int expect(bool condition, const char* label) {
+    if (condition) { return 0; }
+    std::cerr << "expectation failed: " << label << '\n';
+    return 1;
+}
+
+std::byte* at(const ninfer::DeviceSpan& arena, std::size_t offset) {
+    return static_cast<std::byte*>(arena.data) + offset;
+}
+
+void fill(void* destination, std::byte value, std::size_t bytes) {
+    CUDA_CHECK(cudaMemset(destination, static_cast<int>(value), bytes));
+}
+
+std::byte read_one(const void* source) {
+    std::byte value{};
+    CUDA_CHECK(cudaMemcpy(&value, source, 1, cudaMemcpyDeviceToHost));
+    return value;
+}
+
+} // namespace
+
+int main() {
+    int count                   = 0;
+    const cudaError_t count_err = cudaGetDeviceCount(&count);
+    if (cuda_unavailable(count_err) || (count_err == cudaSuccess && count == 0)) {
+        std::cout << "SKIP: no usable CUDA device\n";
+        return 77;
+    }
+    if (count_err != cudaSuccess) {
+        std::cerr << "cudaGetDeviceCount failed: " << cudaGetErrorString(count_err) << '\n';
+        return 1;
+    }
+
+    try {
+        ninfer::DeviceContext device(0);
+        if (!ninfer::EvictableKVPool::supported(device)) {
+            std::cout << "SKIP: device does not support CUDA virtual memory management\n";
+            return 77;
+        }
+
+        int failures = 0;
+        // Sized in granules once the pool reports the device granularity: build a throwaway pool
+        // with a one-granule window to learn it, then the real fixture.
+        std::size_t granule = 0;
+        {
+            ninfer::EvictableKVPool probe(device, ninfer::EvictableKVPool::Config{
+                                                      .arena_bytes           = 8ULL << 20,
+                                                      .lendable_prefix_bytes = 8ULL << 20,
+                                                      .window_capacity_bytes = 1,
+                                                  });
+            granule = probe.granularity();
+            failures += expect(granule != 0 && (granule & (granule - 1)) == 0,
+                               "granularity is a nonzero power of two");
+        }
+
+        // Six granules of payload plus a deliberately unaligned resident remainder.
+        const std::size_t payload_bytes = 6 * granule;
+        const std::size_t arena_bytes   = payload_bytes + granule / 2 + 4096;
+        ninfer::EvictableKVPool pool(device, ninfer::EvictableKVPool::Config{
+                                                 .arena_bytes           = arena_bytes,
+                                                 .lendable_prefix_bytes = payload_bytes,
+                                                 .window_capacity_bytes = 3 * granule,
+                                             });
+
+        const ninfer::DeviceSpan arena = pool.arena();
+        void* const stable_base        = arena.data;
+        failures += expect(arena.bytes == arena_bytes, "arena span covers the configured bytes");
+        failures += expect(reinterpret_cast<std::uintptr_t>(arena.data) % granule == 0,
+                           "arena base is granularity aligned");
+        failures += expect(pool.lendable_granules() == 6, "the payload prefix is six granules");
+        failures += expect(pool.window_capacity_bytes() == 3 * granule,
+                           "window capacity is reported in whole granules");
+        failures += expect(pool.granule_of(0) == 0 && pool.granule_of(granule) == 1 &&
+                               pool.granule_of(granule * 5 + 17) == 5,
+                           "granule_of maps arena offsets to granules");
+        failures += expect(pool.granule_bytes(2).data == at(arena, 2 * granule) &&
+                               pool.granule_bytes(2).bytes == granule,
+                           "granule_bytes describes the home range");
+
+        // Whole arena carries a marker; the lease must leave everything outside it alone.
+        constexpr std::byte kResident{0x5a};
+        fill(arena.data, kResident, arena_bytes);
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        {
+            const std::size_t granules[] = {1, 3, 4};
+            ninfer::EvictableKVPool::Transaction lease =
+                pool.lease(std::span<const std::size_t>(granules), device.stream);
+            failures += expect(lease.open() && pool.lease_open(), "lease opens a transaction");
+            failures += expect(lease.leased().bytes == 3 * granule,
+                               "the leased span covers the requested granules");
+            failures += expect(lease.stats().mapped_bytes == 3 * granule,
+                               "lease stats report the mapped bytes");
+
+            // The window is usable memory: writing it must not disturb the resident granules.
+            constexpr std::byte kWindow{0x27};
+            fill(lease.leased().data, kWindow, lease.leased().bytes);
+            CUDA_CHECK(cudaDeviceSynchronize());
+            failures += expect(read_one(at(arena, 0)) == kResident,
+                               "granule 0 is untouched while granule 1 is lent");
+            failures += expect(read_one(at(arena, 2 * granule)) == kResident,
+                               "granule 2 is untouched while granules 3 and 4 are lent");
+            failures += expect(read_one(at(arena, 5 * granule)) == kResident,
+                               "the last payload granule is untouched");
+            failures += expect(read_one(at(arena, payload_bytes + 1024)) == kResident,
+                               "the resident remainder is untouched");
+
+            bool nested_rejected = false;
+            const std::size_t other[] = {0};
+            try {
+                auto second = pool.lease(std::span<const std::size_t>(other), device.stream);
+                (void)second;
+            } catch (const std::logic_error&) { nested_rejected = true; }
+            failures += expect(nested_rejected, "a nested lease is rejected");
+
+            lease.close();
+            failures += expect(!lease.open() && !pool.lease_open(),
+                               "close returns the granules home");
+            failures += expect(!pool.poisoned(), "a clean close does not poison the pool");
+            failures += expect(pool.arena().data == stable_base, "the home base never moves");
+        }
+
+        // The pool is usable again and the previously lent granules are mapped, if garbage.
+        {
+            const std::size_t granules[] = {1};
+            ninfer::EvictableKVPool::Transaction lease =
+                pool.lease(std::span<const std::size_t>(granules), device.stream);
+            failures += expect(lease.leased().bytes == granule, "a one-granule lease");
+        }
+        failures += expect(!pool.lease_open(), "the destructor closes the lease");
+        fill(at(arena, granule), kResident, granule);
+        CUDA_CHECK(cudaDeviceSynchronize());
+        failures += expect(read_one(at(arena, granule)) == kResident,
+                           "a returned granule is writable at its home address");
+
+        const auto rejects = [&](const std::vector<std::size_t>& granules, const char* label) {
+            bool rejected = false;
+            try {
+                auto lease = pool.lease(std::span<const std::size_t>(granules), device.stream);
+                (void)lease;
+            } catch (const std::exception&) { rejected = true; }
+            failures += expect(rejected, label);
+            failures += expect(!pool.lease_open(), "a rejected lease leaves the arena resident");
+        };
+        rejects({}, "an empty lease is rejected");
+        rejects({6}, "a resident granule cannot be lent");
+        rejects({0, 1, 2, 3}, "a lease beyond the window capacity is rejected");
+        rejects({2, 2}, "duplicate granules are rejected");
+        rejects({3, 1}, "unordered granules are rejected");
+
+        bool window_rejected = false;
+        try {
+            ninfer::EvictableKVPool wide(device, ninfer::EvictableKVPool::Config{
+                                                     .arena_bytes           = arena_bytes,
+                                                     .lendable_prefix_bytes = 2 * granule,
+                                                     .window_capacity_bytes = 3 * granule,
+                                                 });
+        } catch (const std::invalid_argument&) { window_rejected = true; }
+        failures += expect(window_rejected, "a window wider than the payload prefix is rejected");
+
+        // Loan planning over a page pool bound inside the arena: a K-sized plane whose stride
+        // divides the granularity is lendable, a scale-sized plane is not.
+        {
+            const auto page_stride = static_cast<std::int32_t>(granule / 8 / 64 / 2);
+            ninfer::KVPageGeometry geometry{
+                .planes = {{ninfer::DType::I8, page_stride, 2, 256},
+                           {ninfer::DType::FP16, 1, 2, 256}},
+            };
+            ninfer::LayoutBuilder builder;
+            const ninfer::DeviceKVPagePoolLayout layout = ninfer::plan_device_kv_page_pool(
+                builder, {.page_group_count = 512, .geometry = geometry});
+            const std::size_t needed = builder.finish(256, "loan fixture");
+            ninfer::EvictableKVPool fixture(device, ninfer::EvictableKVPool::Config{
+                                                        .arena_bytes           = needed,
+                                                        .lendable_prefix_bytes = needed,
+                                                        .window_capacity_bytes = 4 * granule,
+                                                    });
+            ninfer::DeviceKVPagePool pages(fixture.arena(), layout);
+            const std::uint32_t unit = ninfer::kv_loan_unit_pages(pages, granule);
+            failures += expect(unit == granule / static_cast<std::size_t>(pages.plane(0).nb[3]),
+                               "the loan unit follows the widest lendable plane");
+
+            const ninfer::KVLoanPlan plan = ninfer::plan_kv_loan(fixture, pages, 2 * granule);
+            failures += expect(plan.bytes >= 2 * granule, "the plan covers the request");
+            failures += expect(!plan.runs.empty(), "the plan lends pages");
+            std::size_t previous = 0;
+            bool ordered         = true;
+            for (const std::size_t index : plan.granules) {
+                if (previous != 0 && index <= previous) { ordered = false; }
+                previous = index;
+            }
+            failures += expect(ordered, "planned granules strictly increase");
+
+            // A live page at the top must push the plan away from the granules it backs.
+            std::vector<ninfer::DeviceKVPageLease> live;
+            live.reserve(512);
+            std::optional<ninfer::DeviceKVPageReservation> reservation = pages.reserve(512);
+            pages.materialize(*reservation, 512, live);
+            const ninfer::KVLoanPlan starved = ninfer::plan_kv_loan(fixture, pages, granule);
+            failures += expect(starved.granules.empty(),
+                               "a full pool cannot fund a loan");
+            live.clear();
+            reservation.reset();
+
+            const ninfer::KVLoanPlan huge =
+                ninfer::plan_kv_loan(fixture, pages, 64ULL * granule);
+            failures += expect(huge.granules.empty(), "a request beyond the pool is refused");
+        }
+
+        if (failures != 0) {
+            std::cerr << failures << " expectation(s) failed\n";
+            return 1;
+        }
+        std::cout << "evictable KV pool test passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "evictable KV pool test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/test_evictable_weight_pool.cu
+++ b/tests/test_evictable_weight_pool.cu
@@ -1,0 +1,178 @@
+// Lifetime and integrity qualification for the VMM-backed evictable weight pool: stable arena
+// addresses across transactions, byte-exact restore of the borrowed chunks from the pinned mirror,
+// restore confined to the dirtied extent, and rejection of invalid transactions.
+
+#include "core/arena.h"
+#include "core/device.h"
+#include "core/evictable_weight_pool.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+bool cuda_unavailable(cudaError_t err) {
+    return err == cudaErrorNoDevice || err == cudaErrorInsufficientDriver;
+}
+
+int expect(bool condition, const char* label) {
+    if (condition) { return 0; }
+    std::cerr << "expectation failed: " << label << '\n';
+    return 1;
+}
+
+std::byte* at(const ninfer::DeviceSpan& arena, std::size_t offset) {
+    return static_cast<std::byte*>(arena.data) + offset;
+}
+
+} // namespace
+
+int main() {
+    int count                   = 0;
+    const cudaError_t count_err = cudaGetDeviceCount(&count);
+    if (cuda_unavailable(count_err) || (count_err == cudaSuccess && count == 0)) {
+        std::cout << "SKIP: no usable CUDA device\n";
+        return 77;
+    }
+    if (count_err != cudaSuccess) {
+        std::cerr << "cudaGetDeviceCount failed: " << cudaGetErrorString(count_err) << '\n';
+        return 1;
+    }
+
+    try {
+        ninfer::DeviceContext device(0);
+        if (!ninfer::EvictableWeightPool::supported(device)) {
+            std::cout << "SKIP: device does not support CUDA virtual memory management\n";
+            return 77;
+        }
+
+        constexpr std::size_t kChunk  = ninfer::EvictableWeightPool::kChunkBytes;
+        const std::size_t arena_bytes = 6 * kChunk - (kChunk / 2); // deliberately unaligned
+        const std::size_t tail_bytes  = 3 * kChunk;                // chunks at 3c, 4c, 5c
+
+        ninfer::EvictableWeightPool pool(device, ninfer::EvictableWeightPool::Config{
+                                                     .arena_bytes           = arena_bytes,
+                                                     .evictable_tail_bytes  = tail_bytes,
+                                                     .window_capacity_bytes = 2 * kChunk,
+                                                 });
+
+        int failures                   = 0;
+        const ninfer::DeviceSpan arena = pool.arena();
+        failures += expect(arena.bytes == arena_bytes, "arena span covers the configured bytes");
+        failures += expect(pool.window_capacity_bytes() == 2 * kChunk,
+                           "window capacity rounds to whole chunks");
+        failures += expect(pool.mirror_bytes() == arena_bytes - 4 * kChunk,
+                           "mirror covers exactly the window's weight bytes");
+
+        std::vector<std::uint32_t> pattern(arena_bytes / sizeof(std::uint32_t));
+        for (std::size_t i = 0; i < pattern.size(); ++i) {
+            pattern[i] = static_cast<std::uint32_t>(i * 2654435761ULL + 12345U);
+        }
+        CUDA_CHECK(cudaMemcpyAsync(arena.data, pattern.data(),
+                                   pattern.size() * sizeof(std::uint32_t),
+                                   cudaMemcpyHostToDevice, device.stream));
+        bool early_rejected = false;
+        try {
+            (void)pool.evict(kChunk, device.stream);
+        } catch (const std::logic_error&) { early_rejected = true; }
+        failures += expect(early_rejected, "evict before the mirror capture is rejected");
+        pool.capture_window_mirror(device.stream);
+        failures += expect(pool.mirror_captured(), "mirror capture is recorded");
+
+        const void* stable_base = arena.data;
+        std::vector<std::uint32_t> readback(pattern.size());
+        const auto read_arena = [&] {
+            CUDA_CHECK(cudaMemcpyAsync(readback.data(), arena.data,
+                                       readback.size() * sizeof(std::uint32_t),
+                                       cudaMemcpyDeviceToHost, device.stream));
+            CUDA_CHECK(cudaStreamSynchronize(device.stream));
+        };
+
+        for (int cycle = 0; cycle < 2; ++cycle) {
+            auto transaction = pool.evict(kChunk + kChunk / 2, device.stream);
+            failures += expect(transaction.open(), "evict opens a transaction");
+            failures += expect(transaction.leased().bytes == 2 * kChunk,
+                               "evict rounds the extent up to chunks");
+            failures += expect(pool.transaction_open(), "pool reports the open transaction");
+            CUDA_CHECK(cudaMemsetAsync(transaction.leased().data, 0xC3, transaction.leased().bytes,
+                                       device.stream));
+            CUDA_CHECK(cudaStreamSynchronize(device.stream));
+            transaction.close();
+            failures += expect(!transaction.open() && !pool.transaction_open(),
+                               "close ends the transaction");
+            failures += expect(!pool.poisoned(), "a clean close does not poison the pool");
+            failures += expect(pool.arena().data == stable_base,
+                               "arena base is stable across transactions");
+            transaction.close(); // idempotent
+            read_arena();
+            failures += expect(std::memcmp(readback.data(), pattern.data(),
+                                           pattern.size() * sizeof(std::uint32_t)) == 0,
+                               "restored arena is byte-identical to the mirror image");
+        }
+
+        {
+            // Restore must touch only the borrowed chunk: a byte outside the window (chunk 3c)
+            // and a byte inside the window but outside a one-chunk transaction (chunk 4c) both
+            // keep a deliberate corruption, while the borrowed chunk (5c) comes back exact.
+            const std::byte poison{0xEE};
+            CUDA_CHECK(cudaMemcpy(at(arena, 3 * kChunk), &poison, 1, cudaMemcpyHostToDevice));
+            CUDA_CHECK(cudaMemcpy(at(arena, 4 * kChunk), &poison, 1, cudaMemcpyHostToDevice));
+            {
+                auto transaction = pool.evict(kChunk, device.stream);
+                failures += expect(transaction.leased().bytes == kChunk, "one-chunk window");
+                CUDA_CHECK(cudaMemsetAsync(transaction.leased().data, 0x11, kChunk,
+                                           device.stream));
+                CUDA_CHECK(cudaStreamSynchronize(device.stream));
+            } // destructor closes the transaction
+            failures += expect(!pool.transaction_open(), "destructor closes the transaction");
+            read_arena();
+            const auto* bytes = reinterpret_cast<const std::byte*>(readback.data());
+            failures += expect(bytes[3 * kChunk] == poison,
+                               "restore did not rewrite bytes outside the window");
+            failures += expect(bytes[4 * kChunk] == poison,
+                               "restore did not rewrite the undirtied window chunk");
+            failures += expect(std::memcmp(bytes + 5 * kChunk,
+                                           reinterpret_cast<const std::byte*>(pattern.data()) +
+                                               5 * kChunk,
+                                           arena_bytes - 5 * kChunk) == 0,
+                               "the borrowed chunk was restored byte-exact");
+        }
+
+        bool nested_rejected = false;
+        {
+            auto outer = pool.evict(kChunk, device.stream);
+            try {
+                (void)pool.evict(kChunk, device.stream);
+            } catch (const std::logic_error&) { nested_rejected = true; }
+        }
+        failures += expect(nested_rejected, "a nested transaction is rejected");
+
+        bool oversize_rejected = false;
+        try {
+            (void)pool.evict(3 * kChunk, device.stream);
+        } catch (const std::invalid_argument&) { oversize_rejected = true; }
+        failures += expect(oversize_rejected, "evict beyond the window capacity is rejected");
+        failures += expect(!pool.transaction_open(), "rejected evict leaves the pool resident");
+
+        bool oversize_window_rejected = false;
+        try {
+            ninfer::EvictableWeightPool too_wide(device, ninfer::EvictableWeightPool::Config{
+                                                             .arena_bytes           = arena_bytes,
+                                                             .evictable_tail_bytes  = tail_bytes,
+                                                             .window_capacity_bytes = 4 * kChunk,
+                                                         });
+        } catch (const std::invalid_argument&) { oversize_window_rejected = true; }
+        failures += expect(oversize_window_rejected, "a window wider than the tail is rejected");
+
+        return failures == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "evictable weight pool test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -158,6 +158,62 @@ bool page_payload_zero(ninfer::HostKVAllocationConstView view, std::uint32_t pag
     return true;
 }
 
+int exercise_page_lending(ninfer::DeviceContext& context) {
+    (void)context;
+    int failures = 0;
+    ninfer::KVPageGeometry geometry{
+        .planes = {{ninfer::DType::I8, 8, 2, 256}, {ninfer::DType::FP16, 1, 2, 256}},
+    };
+    PlannedCache plan = plan_cache(16, 16, 1, geometry);
+    ninfer::DeviceArena arena(plan.bytes);
+    ninfer::DeviceKVPagePool pool({arena.base(), arena.capacity()}, plan.pages);
+
+    failures += expect_size(pool.free_runs().size(), 1, "a fresh pool has one free run");
+    failures += expect_size(pool.free_runs()[0].count, 16, "the free run covers the pool");
+
+    const ninfer::KVPlaneByteRange range = pool.plane_page_range(0, 4, 2);
+    const std::size_t page_bytes         = static_cast<std::size_t>(pool.plane(0).nb[3]);
+    failures += expect(range.base == static_cast<const std::byte*>(pool.plane(0).data) +
+                                         4 * page_bytes,
+                       "plane_page_range starts at the first page of the run");
+    failures += expect_size(range.bytes, 2 * page_bytes, "plane_page_range covers both pages");
+
+    pool.lend_pages(8, 4);
+    failures += expect_size(pool.lent_pages(), 4, "lent pages are counted");
+    failures += expect_size(pool.capacity_pages(), 16, "the physical extent is unchanged");
+    failures += expect_size(pool.usable_pages(), 12, "usable pages exclude the loan");
+    failures += expect_size(pool.available_pages(), 12, "available pages exclude the loan");
+    failures += expect_size(pool.free_runs().size(), 2, "the loan splits the free run");
+
+    // Every page the pool hands out while the loan is open must avoid the lent range: the twelve
+    // usable pages are 0-7 and 12-15, which the allocator can only deliver as two runs.
+    std::vector<ninfer::DeviceKVPageLease> leases = materialize(pool, 12);
+    failures += expect(!pool.reserve(1).has_value(), "a lent page cannot be reserved");
+    failures += expect_size(pool.available_pages(), 0, "no page is left while the loan is open");
+    failures += expect(pool.contiguous_run_count(handles(leases)) == 2,
+                       "materialization crossed the lent range");
+
+    bool overlap_rejected = false;
+    try {
+        pool.lend_pages(0, 2);
+    } catch (const std::invalid_argument&) { overlap_rejected = true; }
+    failures += expect(overlap_rejected, "lending allocated pages is rejected");
+
+    leases.clear();
+    pool.return_pages(8, 4);
+    failures += expect_size(pool.lent_pages(), 0, "the loan is returned");
+    failures += expect_size(pool.usable_pages(), 16, "usable pages recover");
+    failures += expect_size(pool.free_runs().size(), 1, "the returned run coalesces");
+    failures += expect_size(pool.free_runs()[0].count, 16, "the free run covers the pool again");
+
+    bool outside_rejected = false;
+    try {
+        pool.lend_pages(14, 4);
+    } catch (const std::out_of_range&) { outside_rejected = true; }
+    failures += expect(outside_rejected, "a loan past the pool is rejected");
+    return failures;
+}
+
 int exercise_reservation_and_mapping(ninfer::DeviceContext& context) {
     int failures = 0;
     ninfer::KVPageGeometry geometry{
@@ -434,6 +490,7 @@ int main() {
     try {
         ninfer::DeviceContext context(0);
         int failures = exercise_reservation_and_mapping(context);
+        failures += exercise_page_lending(context);
         failures += exercise_layout_and_transfer(
             context,
             ninfer::KVPageGeometry{

--- a/tests/test_serve_options.cpp
+++ b/tests/test_serve_options.cpp
@@ -321,5 +321,38 @@ int main() {
     failures += check(redaction_present, "startup argv omitted the API-key redaction marker");
 
     if (failures == 0) { std::cout << "ok\n"; }
+
+    {
+        const ServeOptions overlay =
+            parse({"ninfer-serve", "model.ninfer", "--vision", "--vision-residency", "overlay",
+                   "--vision-max-merged", "12288"});
+        failures += check(overlay.vision_residency == ninfer::VisionResidency::Overlay,
+                          "--vision-residency overlay did not select overlay residency");
+        failures += check(overlay.vision_max_merged_tokens == 12288U,
+                          "--vision-max-merged did not set the merged-token budget");
+        const ServeOptions resident = parse({"ninfer-serve", "model.ninfer", "--vision"});
+        failures += check(resident.vision_residency == ninfer::VisionResidency::Resident,
+                          "vision residency does not default to resident");
+        failures += check(resident.vision_max_merged_tokens == 16384U,
+                          "vision merged-token budget does not default to the item maximum");
+        bool overlay_without_vision_rejected = false;
+        try {
+            (void)parse({"ninfer-serve", "model.ninfer", "--vision-residency", "overlay"});
+        } catch (const std::invalid_argument&) { overlay_without_vision_rejected = true; }
+        failures += check(overlay_without_vision_rejected,
+                          "--vision-residency overlay without --vision was accepted");
+        bool small_budget_rejected = false;
+        try {
+            (void)parse({"ninfer-serve", "model.ninfer", "--vision", "--vision-max-merged", "32"});
+        } catch (const std::invalid_argument&) { small_budget_rejected = true; }
+        failures += check(small_budget_rejected, "--vision-max-merged 32 was accepted");
+        bool unknown_mode_rejected = false;
+        try {
+            (void)parse(
+                {"ninfer-serve", "model.ninfer", "--vision", "--vision-residency", "sometimes"});
+        } catch (const std::invalid_argument&) { unknown_mode_rejected = true; }
+        failures += check(unknown_mode_rejected, "--vision-residency sometimes was accepted");
+    }
+
     return failures == 0 ? 0 : 1;
 }

--- a/tests/test_vmm_graph_remap.cu
+++ b/tests/test_vmm_graph_remap.cu
@@ -1,0 +1,191 @@
+// Proves the residency mechanism behind the vision VRAM overlay: physical chunks
+// backing a stable VA range can be unmapped, remapped into a different reserved
+// range, used there, remapped home, and re-uploaded from a pinned host mirror --
+// all while a CUDA graph captured against the home addresses stays launchable
+// and correct. Also reports per-chunk map/unmap latency for the overlay budget.
+
+#include "core/arena.h"
+#include "core/device.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+bool cuda_unavailable(cudaError_t err) {
+    return err == cudaErrorNoDevice || err == cudaErrorInsufficientDriver;
+}
+
+void cu_check(CUresult result, const char* expr) {
+    if (result == CUDA_SUCCESS) { return; }
+    const char* name = nullptr;
+    (void)cuGetErrorName(result, &name);
+    throw std::runtime_error(std::string(expr) + " failed: " +
+                             (name != nullptr ? name : "unknown CUresult"));
+}
+
+#define CU_CHECK(expr) ::cu_check((expr), #expr)
+
+constexpr std::size_t kChunkCount   = 4;
+constexpr std::size_t kEvictedFirst = 2;   // evict the chunk suffix [2, 4)
+
+__global__ void checksum_kernel(const std::uint32_t* words, std::size_t count,
+                                unsigned long long* out) {
+    unsigned long long local = 0;
+    for (std::size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < count;
+         i += static_cast<std::size_t>(gridDim.x) * blockDim.x) {
+        local += words[i];
+    }
+    atomicAdd(out, local);
+}
+
+void map_rw(CUdeviceptr va, std::size_t bytes, CUmemGenericAllocationHandle handle, int device) {
+    CU_CHECK(cuMemMap(va, bytes, 0, handle, 0));
+    CUmemAccessDesc access{};
+    access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    access.location.id   = device;
+    access.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    CU_CHECK(cuMemSetAccess(va, bytes, &access, 1));
+}
+
+} // namespace
+
+int main() {
+    int count                   = 0;
+    const cudaError_t count_err = cudaGetDeviceCount(&count);
+    if (cuda_unavailable(count_err) || (count_err == cudaSuccess && count == 0)) {
+        std::cout << "SKIP: no usable CUDA device\n";
+        return 77;
+    }
+    if (count_err != cudaSuccess) {
+        std::cerr << "cudaGetDeviceCount failed: " << cudaGetErrorString(count_err) << '\n';
+        return 1;
+    }
+
+    try {
+        ninfer::DeviceContext device(0);
+        CU_CHECK(cuInit(0));
+
+        CUmemAllocationProp prop{};
+        prop.type          = CU_MEM_ALLOCATION_TYPE_PINNED;
+        prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        prop.location.id   = device.device;
+        std::size_t granularity = 0;
+        CU_CHECK(cuMemGetAllocationGranularity(&granularity, &prop,
+                                               CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+        const std::size_t chunk =
+            ((64ULL << 20) + granularity - 1) / granularity * granularity;
+        const std::size_t total = chunk * kChunkCount;
+
+        CUdeviceptr home = 0, overlay = 0;
+        CU_CHECK(cuMemAddressReserve(&home, total, granularity, 0, 0));
+        CU_CHECK(cuMemAddressReserve(&overlay, total, granularity, 0, 0));
+
+        std::vector<CUmemGenericAllocationHandle> handles(kChunkCount);
+        for (std::size_t i = 0; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemCreate(&handles[i], chunk, &prop, 0));
+            map_rw(home + i * chunk, chunk, handles[i], device.device);
+        }
+
+        // Deterministic pattern, mirrored in pinned host memory like the
+        // production weight mirrors.
+        ninfer::PinnedHostBuffer mirror(total);
+        auto* mirror_words = static_cast<std::uint32_t*>(mirror.data());
+        for (std::size_t i = 0; i < total / sizeof(std::uint32_t); ++i) {
+            mirror_words[i] = static_cast<std::uint32_t>(i * 2654435761ULL);
+        }
+        CUDA_CHECK(cudaMemcpyAsync(reinterpret_cast<void*>(home), mirror.data(), total,
+                                   cudaMemcpyHostToDevice, device.stream));
+
+        unsigned long long* result = nullptr;
+        CUDA_CHECK(cudaMalloc(&result, sizeof(unsigned long long)));
+        CUDA_CHECK(cudaMemsetAsync(result, 0, sizeof(unsigned long long), device.stream));
+        device.synchronize();
+
+        // Reference checksum with everything resident.
+        const std::size_t words = total / sizeof(std::uint32_t);
+        checksum_kernel<<<256, 256, 0, device.stream>>>(
+            reinterpret_cast<const std::uint32_t*>(home), words, result);
+        unsigned long long expected = 0;
+        CUDA_CHECK(cudaMemcpyAsync(&expected, result, sizeof(expected), cudaMemcpyDeviceToHost,
+                                   device.stream));
+        device.synchronize();
+
+        // Capture the checksum as a graph against the home addresses.
+        cudaGraph_t graph         = nullptr;
+        cudaGraphExec_t execution = nullptr;
+        CUDA_CHECK(cudaStreamBeginCapture(device.stream, cudaStreamCaptureModeGlobal));
+        CUDA_CHECK(cudaMemsetAsync(result, 0, sizeof(unsigned long long), device.stream));
+        checksum_kernel<<<256, 256, 0, device.stream>>>(
+            reinterpret_cast<const std::uint32_t*>(home), words, result);
+        CUDA_CHECK(cudaStreamEndCapture(device.stream, &graph));
+        CUDA_CHECK(cudaGraphInstantiate(&execution, graph, nullptr, nullptr, 0));
+
+        // Overlay transaction: unmap the chunk suffix, remap the same physical
+        // pages into the overlay range, scribble there (vision stand-in),
+        // remap home, and restore only the evicted bytes from the mirror.
+        const std::size_t evicted_bytes  = (kChunkCount - kEvictedFirst) * chunk;
+        const std::size_t evicted_offset = kEvictedFirst * chunk;
+        const auto evict_start           = std::chrono::steady_clock::now();
+        for (std::size_t i = kEvictedFirst; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemUnmap(home + i * chunk, chunk));
+            map_rw(overlay + (i - kEvictedFirst) * chunk, chunk, handles[i], device.device);
+        }
+        const auto evict_end = std::chrono::steady_clock::now();
+        CUDA_CHECK(cudaMemsetAsync(reinterpret_cast<void*>(overlay), 0xA5, evicted_bytes,
+                                   device.stream));
+        device.synchronize();
+        const auto restore_start = std::chrono::steady_clock::now();
+        for (std::size_t i = kEvictedFirst; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemUnmap(overlay + (i - kEvictedFirst) * chunk, chunk));
+            map_rw(home + i * chunk, chunk, handles[i], device.device);
+        }
+        const auto restore_end = std::chrono::steady_clock::now();
+        CUDA_CHECK(cudaMemcpyAsync(reinterpret_cast<void*>(home + evicted_offset),
+                                   mirror_words + evicted_offset / sizeof(std::uint32_t),
+                                   evicted_bytes, cudaMemcpyHostToDevice, device.stream));
+        device.synchronize();
+
+        // The pre-captured graph must still run and see restored bytes.
+        CUDA_CHECK(cudaGraphLaunch(execution, device.stream));
+        unsigned long long actual = 0;
+        CUDA_CHECK(cudaMemcpyAsync(&actual, result, sizeof(actual), cudaMemcpyDeviceToHost,
+                                   device.stream));
+        device.synchronize();
+
+        const auto micros = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        };
+        std::cout << "chunk_bytes=" << chunk << " granularity=" << granularity
+                  << " evict_map_us=" << micros(evict_start, evict_end)
+                  << " restore_map_us=" << micros(restore_start, restore_end) << '\n';
+
+        int failures = 0;
+        if (actual != expected) {
+            std::cerr << "graph checksum after overlay transaction expected " << expected
+                      << ", got " << actual << '\n';
+            ++failures;
+        }
+
+        CUDA_CHECK(cudaGraphExecDestroy(execution));
+        CUDA_CHECK(cudaGraphDestroy(graph));
+        CUDA_CHECK(cudaFree(result));
+        for (std::size_t i = 0; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemUnmap(home + i * chunk, chunk));
+            CU_CHECK(cuMemRelease(handles[i]));
+        }
+        CU_CHECK(cuMemAddressFree(home, total));
+        CU_CHECK(cuMemAddressFree(overlay, total));
+        return failures == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "vmm graph remap test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tools/smoke/overlay_ab.py
+++ b/tools/smoke/overlay_ab.py
@@ -1,0 +1,116 @@
+"""Resident-vs-overlay A/B driver for the vision VRAM overlay.
+
+Talks to a running ninfer-serve over the OpenAI chat route with one generated
+test image, greedy sampling, and prints the exact completion text plus usage so
+two runs can be diffed byte-for-byte. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import concurrent.futures
+import json
+import struct
+import sys
+import time
+import urllib.request
+
+
+def gradient_bmp(width: int, height: int) -> bytes:
+    """Uncompressed 24-bit BMP with a deterministic gradient."""
+    row_bytes = (width * 3 + 3) & ~3
+    image_bytes = row_bytes * height
+    header = struct.pack(
+        "<2sIHHIIiiHHIIiiII",
+        b"BM", 54 + image_bytes, 0, 0, 54,
+        40, width, height, 1, 24, 0, image_bytes, 2835, 2835, 0, 0,
+    )
+    rows = bytearray()
+    for y in range(height):
+        row = bytearray()
+        for x in range(width):
+            row += bytes(((x * 7 + y * 3) % 256, (x + 2 * y) % 256, (255 - (x // 8 + y // 8)) % 256))
+        row += b"\x00" * (row_bytes - len(row))
+        rows += row
+    return header + bytes(rows)
+
+
+def chat(base_url: str, model: str, messages: list, max_tokens: int, timeout: float = 600.0) -> dict:
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "enable_thinking": False,
+    }).encode()
+    request = urllib.request.Request(
+        base_url + "/v1/chat/completions", data=payload,
+        headers={"Content-Type": "application/json"})
+    started = time.monotonic()
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = json.loads(response.read())
+    body["_wall_seconds"] = round(time.monotonic() - started, 3)
+    return body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:18099")
+    parser.add_argument("--model", default="qwen3.8-27b")
+    parser.add_argument("--label", default="run")
+    parser.add_argument("--width", type=int, default=1920)
+    parser.add_argument("--height", type=int, default=1080)
+    parser.add_argument("--concurrency-probe", action="store_true",
+                        help="run two text requests in parallel with the image request")
+    args = parser.parse_args()
+
+    image = gradient_bmp(args.width, args.height)
+    data_uri = "data:image/bmp;base64," + base64.b64encode(image).decode()
+    image_messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text",
+             "text": "Describe the colors and structure of this image in one sentence."},
+            {"type": "image_url", "image_url": {"url": data_uri}},
+        ],
+    }]
+
+    def text_request(tag: str) -> dict:
+        return chat(args.base_url, args.model,
+                    [{"role": "user", "content": f"Count from 1 to 5. ({tag})"}], 32)
+
+    results = {}
+    if args.concurrency_probe:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+            image_future = pool.submit(chat, args.base_url, args.model, image_messages, 64)
+            text_a = pool.submit(text_request, "a")
+            text_b = pool.submit(text_request, "b")
+            results["image"] = image_future.result()
+            results["text_a"] = text_a.result()
+            results["text_b"] = text_b.result()
+    else:
+        results["image"] = chat(args.base_url, args.model, image_messages, 64)
+
+    # Follow-up turn over the same image: prefix reuse must avoid a re-encode.
+    followup = image_messages + [
+        {"role": "assistant",
+         "content": results["image"]["choices"][0]["message"]["content"]},
+        {"role": "user", "content": "Now answer with exactly one word: what is the dominant hue?"},
+    ]
+    results["followup"] = chat(args.base_url, args.model, followup, 16)
+
+    for name, body in results.items():
+        message = body["choices"][0]["message"]
+        usage = body.get("usage", {})
+        print(f"[{args.label}:{name}] wall={body['_wall_seconds']}s "
+              f"prompt={usage.get('prompt_tokens')} completion={usage.get('completion_tokens')}")
+        print(f"[{args.label}:{name}] text={json.dumps(message.get('content', ''), ensure_ascii=False)}")
+        reasoning = message.get("reasoning_content") or message.get("reasoning") or ""
+        if reasoning:
+            print(f"[{args.label}:{name}] reasoning={json.dumps(reasoning[:600], ensure_ascii=False)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/smoke/vision_stall_probe.py
+++ b/tools/smoke/vision_stall_probe.py
@@ -1,0 +1,150 @@
+"""Measures how long a text lane stalls while an image is encoded.
+
+Streams one long text completion and, once it is producing tokens, sends an
+image request on a second lane. Reports the inter-token gaps of the text
+stream: with a KV-funded window the encode runs beside the decode and the gaps
+stay small, with a weight-tail window the whole engine waits for it.
+Stdlib only; reuses the deterministic gradient image of overlay_ab.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import struct
+import sys
+import threading
+import time
+import urllib.request
+
+
+def gradient_bmp(width: int, height: int) -> bytes:
+    """Uncompressed 24-bit BMP with a deterministic gradient."""
+    row_bytes = (width * 3 + 3) & ~3
+    image_bytes = row_bytes * height
+    header = struct.pack(
+        "<2sIHHIIiiHHIIiiII",
+        b"BM", 54 + image_bytes, 0, 0, 54,
+        40, width, height, 1, 24, 0, image_bytes, 2835, 2835, 0, 0,
+    )
+    rows = bytearray()
+    for y in range(height):
+        row = bytearray()
+        for x in range(width):
+            row += bytes(((x * 7 + y * 3) % 256, (x + 2 * y) % 256, (255 - (x // 8 + y // 8)) % 256))
+        row += b"\x00" * (row_bytes - len(row))
+        rows += row
+    return header + bytes(rows)
+
+
+def post(base_url: str, payload: dict, timeout: float = 900.0):
+    request = urllib.request.Request(
+        base_url + "/v1/chat/completions", data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"})
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def stream_gaps(base_url: str, model: str, prompt: str, max_tokens: int,
+                started_event: threading.Event, out: dict) -> None:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "enable_thinking": False,
+        "stream": True,
+    }
+    gaps = []
+    previous = None
+    tokens = 0
+    with post(base_url, payload) as response:
+        for raw in response:
+            line = raw.decode(errors="replace").strip()
+            if not line.startswith("data:"):
+                continue
+            body = line[5:].strip()
+            if body == "[DONE]":
+                break
+            try:
+                chunk = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            delta = chunk.get("choices", [{}])[0].get("delta", {})
+            if not delta.get("content"):
+                continue
+            now = time.monotonic()
+            tokens += 1
+            if previous is not None:
+                gaps.append(now - previous)
+            previous = now
+            if tokens == 8:
+                started_event.set()
+    out["tokens"] = tokens
+    out["gaps"] = gaps
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:18099")
+    parser.add_argument("--model", default="m")
+    parser.add_argument("--label", default="probe")
+    parser.add_argument("--width", type=int, default=1920)
+    parser.add_argument("--height", type=int, default=1080)
+    parser.add_argument("--text-tokens", type=int, default=256)
+    args = parser.parse_args()
+
+    data_uri = "data:image/bmp;base64," + base64.b64encode(
+        gradient_bmp(args.width, args.height)).decode()
+    image_payload = {
+        "model": args.model,
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text",
+                 "text": "Describe the colors and structure of this image in one sentence."},
+                {"type": "image_url", "image_url": {"url": data_uri}},
+            ],
+        }],
+        "max_tokens": 48,
+        "temperature": 0,
+        "enable_thinking": False,
+    }
+
+    started = threading.Event()
+    text_out: dict = {}
+    text_thread = threading.Thread(
+        target=stream_gaps,
+        args=(args.base_url, args.model,
+              "Write a detailed essay about the history of cartography, in full sentences.",
+              args.text_tokens, started, text_out))
+    text_thread.start()
+    if not started.wait(timeout=120):
+        print(f"[{args.label}] text stream never started")
+        text_thread.join()
+        return 1
+
+    image_started = time.monotonic()
+    with post(args.base_url, image_payload) as response:
+        image = json.loads(response.read())
+    image_wall = time.monotonic() - image_started
+    text_thread.join()
+
+    gaps = sorted(text_out.get("gaps", []))
+    if not gaps:
+        print(f"[{args.label}] text stream produced no gaps")
+        return 1
+    worst = gaps[-1]
+    median = gaps[len(gaps) // 2]
+    content = image["choices"][0]["message"]["content"]
+    print(f"[{args.label}] text_tokens={text_out['tokens']} "
+          f"gap_max={worst * 1000:.0f}ms gap_p50={median * 1000:.0f}ms "
+          f"gap_p99={gaps[int(len(gaps) * 0.99)] * 1000:.0f}ms")
+    print(f"[{args.label}] image_wall={image_wall:.2f}s "
+          f"prompt={image.get('usage', {}).get('prompt_tokens')}")
+    print(f"[{args.label}] image_text={json.dumps(content, ensure_ascii=False)[:160]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`--vision-residency overlay` removes the resident device cost of `--vision` on 24 GiB cards, rebuilt on the v0.6.2 resource model (Program-owned stores, single workspace, affine KV capacity curve). The Vision tower lives in pinned host memory, the sequence plan reserves nothing for Vision, and each image is encoded inside a bounded window that borrows device memory for the duration of the encode. With `--kv-capacity auto` the engine resolves the same KV capacity as without `--vision`.

A window is funded from free KV pages when they cover it: nothing is copied, the text weights stay mapped, and the encode runs on its own stream while the other lanes keep decoding. Otherwise it borrows the evict-ranked tail of the text weights and is exclusive. The fallback is always available, so a vision request never fails for lack of memory once admitted.

Default behaviour (`--vision-residency resident`) is unchanged in numbers and code paths. Supersedes #8.

## Design

- **Placement.** `TensorPlacement::HostPinned` lands the Vision group in one pinned block. Text endpoints carry evict ranks (MTP 400 < draft head 500 < token embedding 600 < lm_head 700) and are packed at a chunk-aligned arena tail (`MaterializationPlan::evictable_tail_offset`).
- **Plan.** In overlay mode `WorkspacePlan::vision_resident == false`: the encode workspace and the item handoff are not folded into the workspace capacity, so the capacity curve equals the no-vision curve plus a 10 MiB per-chunk staging tensor. `--vision-max-merged` (default 16384) bounds one item and sizes the window; media above it is downscaled at preprocessing instead of being rejected.
- **Weight tail (`core/evictable_weight_pool`).** The weight arena is backed by CUDA VMM: 16 MiB chunks at stable home addresses, so captured decode graphs stay valid, plus an overlay range sized to one window and a pinned mirror of the bytes a window can dirty. `evict()` quiesces both device streams; `Transaction::close()` remaps home, re-uploads only the dirtied range and never throws — a failed restore poisons the pool and the engine refuses further work.
- **Free KV pages (`core/evictable_kv_pool`).** The persistent arena is reserved as one VMM range backed by granularity-sized pieces. Every store binds at the offsets it used before, so plane pointers, block tables and decode graphs are untouched. Only granules lying entirely inside free KV pages are unmapped, and returning them copies nothing: free pages carry no content and no page is read before the append kernel writes it.
- **Loan unit.** A granule spans 32 pages of the K plane and 64 of the packed V plane, so loans grow in aligned 64-page units and the scale planes (2 KiB per page) are never lent. On the rk8v4 27B one unit frees 96 MiB of the 100 MiB those pages occupy; a 1080p window costs two units.
- **Accounting.** `DeviceKVPagePool::lend_pages` takes the run out of circulation, `usable_pages()` and `admission_capacity()` shrink with it, so nothing is admitted into lent memory. Acquire and release advance the resource revision, and a loan is refused while a context transaction or a pressure-planning session is open.
- **Window.** One window per image. `VisionOverlaySession::submit_item` opens it and enqueues the encode on `vision_stream` as soon as the request's Vision session exists, ahead of the lane's first prefill unit; the tower streams through prelude/merger regions and two layer slots one layer ahead on the transfer stream; the embeddings land in a per-lane pinned slot; `complete_item` closes the window. `Program::vision_pending` reports the wait and the engine's prefill gate skips that lane. Only one lane prefills at a time, so at most one window is open. A follow-up turn over the same image reuses the prefix and opens none.
- **Prefill.** `VisionChunk::host_embeddings` carries the pinned item embeddings; the text prefill uploads only the chunk's columns into `TextPrefillRoots::visual_embeddings`. The MTP bridge does the same for its single column.
- **Safety.** Host-pinned weights are published as `HostVisionWeights`, a distinct type, so no device `VisionContext` can be bound over host pointers. The window budget is validated at plan time against the pool's window capacity.

## Measurements (RTX 3090, sm_86, CUDA 13.1, driver 580)

Dedicated RunPod RTX 3090 (24 GiB), `groupwise-int` Qwen3.8-27B, nothing else on the GPU. Common flags: `--spec mtp --draft-tokens 3 --lm-head-draft`; vision rows add `--vision --vision-max-merged 12288`. Full `ctest` on sm_86: 97/97.

**Maximum `--max-context` that boots** (`--max-concurrency 1 --prefill-chunk 1024`):

| `--kv-dtype` | no `--vision` (auto / explicit) | `--vision`, resident (auto / explicit) | `--vision`, overlay, this PR (auto / explicit) |
|---|---|---|---|
| `int8` | 147 456 / 180 224 | 122 880 / 159 744 | **147 456 / 180 224** |
| `rk8v4` | 196 608 / 237 568 | 163 840 / 210 944 | **196 608 / 237 568** |
| `bf16` | 73 728 / 92 160 | 65 536 / 81 920 | **73 728 / 92 160** |

`auto` is `--kv-capacity auto`, which keeps 1 GiB of headroom; `explicit` is the largest `--kv-capacity N --max-context N` that boots, bisected to 2048 tokens, with a 1920×1080 image request completing at the overlay maximum. Overlay boots the no-vision capacity in every storage mode: the resident cost of 24 576 / 32 768 / 8 192 tokens is gone. At 65 536 tokens the startup reservation drops 2.66 → 2.23 GiB and `free-after-weights` rises 6.35 → 6.61 GiB, the 282 MiB tower being host-pinned.

**Text stall while a 1920×1080 image encodes** (`--max-concurrency 2 --prefill-chunk 256`, rk8v4, `tools/smoke/vision_stall_probe.py`) — inter-token gaps of a text stream running alongside:

| window | KV capacity | gap p50 | gap p99 | gap max | window |
|---|---|---|---|---|---|
| `conc`, free KV pages | 65 536 | 40 ms | 340 ms | **413 ms** | 408 ms |
| `excl`, weight tail | 20 480 | 40 ms | 670 ms | 670 ms | 356 ms |

An exclusive window adds its whole duration to the worst gap, a concurrent one does not. What remains in the first row is the image prompt's own prefill chunks, which block decode either way. The 20 480-token row is a KV cache smaller than one window: it has no pages to lend, so that tier is never built.

**Numerics.** Greedy completions of a 1920×1080 gradient image (2 074 merged tokens), of a 4000×3000 image downscaled by the budget to 11 767 merged tokens, and of their follow-up turns are byte-identical between residencies (`tools/smoke/overlay_ab.py`). At `--max-concurrency 2` two text requests complete alongside the image request.

**Text throughput without images** (7.7k-token prefill / 320-token decode, three runs each in one boot order):

| mode | int8 prefill tok/s | int8 decode tok/s | rk8v4 prefill tok/s | rk8v4 decode tok/s |
|---|---|---|---|---|
| resident | 852–862 | 53–62 | 845–870 | 55–57 |
| overlay | 846–852 | 55–60 | 857–875 | 57–58 |

**Per-image cost** (rk8v4, `--max-concurrency 1`): TTFT 3.55 s against 3.47 s resident for the 1080p image (window 477 ms, 192 MiB evicted in 4 ms and restored in 11 ms, 282 MiB of tower streamed behind compute); TTFT 22.8 s against 23.0 s for the 4000×3000 image (window 6.65 s against ≈7.4 s of resident encode, 784 MiB evicted in 10 ms and restored in 49 ms). Boot-to-boot prefill throughput on the rented card varies by about ±15 % (GPU clocks), so rows are compared within one run only.

**Control on an RTX 4090** (24 GiB, sm_89, same sm_86 binaries): explicit maxima no-vision 176 128 / 231 424 / 90 112, resident 153 600 / 202 752 / 79 872, overlay 174 080 / 231 424 / 90 112. The overlay `int8` value sits one 2048-token step below no-vision because the per-chunk staging tensor lands in the `text_prefill` envelope. A 1920×1080 request succeeds at every overlay maximum with the same completion text. Absolute numbers differ from the 3090 by free-after-weights (6.46 against 6.63 GiB), so the tables above report the 3090 only.

## Limitations

- Windows builds are untested (Linux/sm_86 only).
- 35B-A3B receives code parity only; the artifact does not fit a 24 GiB card.
- Video items are bounded per two-frame group by `--vision-max-merged`; whole-video items above the budget are still rejected at admission.
- A prompt's second and later images are encoded synchronously: one pinned result slot per session means an item may only be submitted while no other item's embeddings are still in use.
- The image prompt's own prefill chunks still block decode. That is the engine's prefill/decode alternation, not the window.
