### PR TITLE
fix(ops): keep the sm_86 W8 linear_add single-column tail on a K-correct kernel

### DIFF
--- a/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
+++ b/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
@@ -73,6 +73,17 @@ __global__ __launch_bounds__(RowsPerCta * 32, 2) void w8_linear_add_decode_kerne
 template <int RowsPerCta>
 void launch_decode(const Tensor& x, const Weight& w, Tensor& residual_out, cudaStream_t stream) {
     static_assert((2048 % RowsPerCta) == 0);
+    // w8_linear_add_decode_kernel bakes K into kDecodeK: it walks exactly 6144 activations and
+    // strides both the code and scale rows by that same constant, taking no runtime K. Handing it
+    // the K=4096 geometry therefore reads 2048 BF16 past the end of x and indexes the weights with
+    // the wrong row stride, which surfaced as an all-NaN column rather than a failure. The sibling
+    // decode kernels in linear/ and linear_pair/ assert their own K; this one did not.
+    if (x.ne[0] != kDecodeK || w.k != kDecodeK || w.padded_shape[1] != kDecodeK) {
+        throw std::invalid_argument("w8 linear_add decode: kernel is specialised for K=6144");
+    }
+    if (x.ne[1] != 1 || residual_out.ne[1] != 1) {
+        throw std::invalid_argument("w8 linear_add decode: kernel requires a single column");
+    }
     w8_linear_add_decode_kernel<RowsPerCta><<<2048 / RowsPerCta, RowsPerCta * 32, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data), static_cast<const std::uint8_t*>(w.qdata),
         static_cast<const std::uint8_t*>(w.scales), static_cast<__nv_bfloat16*>(residual_out.data));

--- a/src/ops/linear_add/w8/w8_linear_add_gemm_splitk.cu
+++ b/src/ops/linear_add/w8/w8_linear_add_gemm_splitk.cu
@@ -68,6 +68,20 @@ constexpr auto kK4096ProjectionLaunchers = make_projection_launchers<4096>(
 constexpr auto kK6144ProjectionLaunchers = make_projection_launchers<6144>(
     std::make_index_sequence<kLastExactCols - kFirstExactCols + 1>{});
 
+// decode_r16 is specialised for K=6144 and takes no runtime K, so it must never see the K=4096
+// geometry -- that is exactly why kK4096Routes sends T=1 to the SIMT schedule while kK6144Routes
+// sends it to DecodeR16. The sm_86 tail paths below slice tokens into kLastExactCols groups and can
+// leave a single-column tail (T = 33, 65, 97 for this shape), so they have to make the same choice
+// the route table does instead of always reaching for the decode kernel.
+void launch_single_column_tail(const Tensor& x, const Weight& weight, Tensor& residual_out,
+                               cudaStream_t stream) {
+    if (weight.k == 6144) {
+        w8_linear_add_decode_r16_launch(x, weight, residual_out, stream);
+        return;
+    }
+    w8_linear_add_simt_r8_c4_launch(/*full=*/false, x, weight, residual_out, stream);
+}
+
 template <int Hidden, int TileCols, int KSplits, int NGroups, int MinBlocks>
 void launch_medium(const Tensor& x, Tensor& residual_out, const Weight& weight,
                    cudaStream_t stream) {
@@ -110,7 +124,7 @@ void w8_linear_add_splitk_mma_launch(const Tensor& x, const Weight& weight, Tens
         if (tail == 1) {
             const Tensor x_slice = x.slice(1, offset, 1);
             Tensor residual_slice = residual_out.slice(1, offset, 1);
-            w8_linear_add_decode_r16_launch(x_slice, weight, residual_slice, stream);
+            launch_single_column_tail(x_slice, weight, residual_slice, stream);
         } else if (tail >= kFirstExactCols) {
             const Tensor x_slice = x.slice(1, offset, tail);
             Tensor residual_slice = residual_out.slice(1, offset, tail);
@@ -140,7 +154,7 @@ void w8_linear_add_medium_splitk_launch(const Tensor& x, const Weight& weight, T
         const Tensor x_slice = x.slice(1, offset, count);
         Tensor residual_slice = residual_out.slice(1, offset, count);
         if (count == 1) {
-            w8_linear_add_decode_r16_launch(x_slice, weight, residual_slice, stream);
+            launch_single_column_tail(x_slice, weight, residual_slice, stream);
         } else {
             w8_linear_add_splitk_mma_launch(x_slice, weight, residual_slice, stream);
         }

--- a/tests/ops/linear_add/test_w8_a16.cpp
+++ b/tests/ops/linear_add/test_w8_a16.cpp
@@ -12,8 +12,14 @@ using ninfer::test::linear_add::WeightFormat;
 int w8_a16_conformance() {
     int failures = 0;
 
+    // The sm_86 (NINFER_SM8X_COMPAT) split-K and medium split-K launchers slice tokens into
+    // 32-column groups, so any T congruent to 1 mod 32 above 32 leaves a single-column tail. That
+    // tail used to go unconditionally to the DecodeR16 kernel, which bakes in K=6144 and so read
+    // past the end of x on the K=4096 geometry -- an all-NaN output column, not a failure. 96 was
+    // covered here but 97 was not. Keep 33/65/97 on both shapes.
     constexpr std::array<std::int32_t, 4> kK4096RouteStarts{2, 49, 129, 641};
-    constexpr std::array<std::int32_t, 5> kK4096RouteInteriors{1, 24, 96, 256, 1024};
+    constexpr std::array<std::int32_t, 8> kK4096RouteInteriors{1,  24,  96,  256,
+                                                              1024, 33,  65,  97};
     failures += ninfer::test::linear_add::run_shape(
         "W8_A16 LinearAdd", WeightFormat::W8G32F16S,
         ShapeCase{2048, 4096, 419U, kK4096RouteStarts, kK4096RouteInteriors});
@@ -23,10 +29,10 @@ int w8_a16_conformance() {
         481,  641,  673,  705,  785,  897,  961,  1024, 1025, 1121, 1281,
         1345, 1409, 1681, 1792, 1793, 1920, 1921, 2017, 2048, 2049,
     };
-    constexpr std::array<std::int32_t, 33> kK6144RouteInteriors{
-        1,    24,   96,   160,  192,  224,  320,  392,  400,  424,  448,
-        464,  560,  656,  688,  744,  840,  928,  992,  1024, 1072, 1200,
-        1312, 1376, 1544, 1736, 1792, 1856, 1920, 1968, 2032, 2048, 4096,
+    constexpr std::array<std::int32_t, 36> kK6144RouteInteriors{
+        1,    24,   96,   160,  192,  224,  320,  392,  400,  424,  448,  464,
+        560,  656,  688,  744,  840,  928,  992,  1024, 1072, 1200, 1312, 1376,
+        1544, 1736, 1792, 1856, 1920, 1968, 2032, 2048, 4096, 33,   65,   97,
     };
     failures += ninfer::test::linear_add::run_shape(
         "W8_A16 LinearAdd", WeightFormat::W8G32F16S,


### PR DESCRIPTION
## Problem

On sm_86 (`NINFER_SM8X_COMPAT`) both W8 `linear_add` split-K launchers slice tokens into 32-column groups and hand a leftover **single column** to `w8_linear_add_decode_r16_launch`:

```cpp
// w8_linear_add_gemm_splitk.cu, both #if defined(NINFER_SM8X_COMPAT) blocks
if (count == 1) {
    w8_linear_add_decode_r16_launch(x_slice, weight, residual_slice, stream);
}
```

That kernel bakes K into a constant:

```cpp
// w8_linear_add_gemm_simt.cu
constexpr int kDecodeK      = 6144;
constexpr int kDecodeGroups = kDecodeK / 32;
...
const auto* code_row  = codes + row * kDecodeK;      // row stride
constexpr int kPhases = kDecodeK / kValuesPerPhase;  // walks 6144 activations
```

It takes no runtime `K`. `linear_add` is the **only** W8 op that serves two geometries — `K=4096` and `K=6144` (`linear_add.cpp`: `if (w.n != 2048 || (w.k != 4096 && w.k != 6144))`). On the `K=4096` shape that tail reads 2048 BF16 past the end of `x` and indexes the weights with the wrong row stride.

The route table already encodes the correct choice — `kK4096Routes` sends `T=1` to `SimtR8C4`, `kK6144Routes` sends it to `DecodeR16` — but the sm_86 tail paths didn't make the same choice.

Affected token counts are `T ≡ 1 (mod 32)` above 32: **T = 33, 65** in the exact split-K route (`T=2..48`, entered when `T>32`) and **T = 65, 97** in the medium split-K route (`T=49..128`). Above 128 the tiled MMA schedules handle their own partial columns.

## Why it mattered

This didn't fail, it corrupted. The out-of-bounds read produced an **entirely NaN output column**, and a diverged forward pass then samples confident-looking tokens out of NaN.

Found on Qwen3.6-35B-A3B, whose GDN `out_proj` is `[2048,4096]`. A prompt-cache marker split prefill so one chunk ended exactly on the marker frontier, at `(base=12432, len=97)`, and layer 0's `gdn_output_projection` returned NaN for that chunk's final token — while every intermediate in the GDN chain (`g`, `beta`, `qkv`, `z`, conv states, q/k/v, recurrent states, `o`, `on`) stayed finite:

```
abs=11920 len=512  nan=0/2048
abs=12432 len=97   nan=2048/2048   <-- chunk clamped to the marker frontier
```

`(base=12432, len=98/99/100/104)` and `(base=11920, len=609)` are all clean, so it is neither length alone nor 32/64 alignment.

## Fix

`launch_single_column_tail()` keeps `DecodeR16` for `K=6144` and uses the SIMT schedule — which takes `K` as a runtime argument — otherwise.

The sibling decode kernels in `linear/` and `linear_pair/` already assert their own `K` and would have thrown loudly; this one had no such check, which is why it corrupted silently. It now asserts `K` and the single column too.

## Blast radius

Audited every W8 op that bakes `K` into a kernel constant. Each other one is locked by its wrapper to a single `K` matching that constant (`attn_input_proj` 2048, `gdn_input_proj` 2048, `linear_pair` 2048, `linear_swiglu` 2048, `sparse_moe` 2048, `linear` 16384), and `linear/` + `linear_pair/` validate it explicitly. `linear_add` is the whole blast radius. The non-sm_86 paths are unaffected.

## Testing

`tests/ops/linear_add/test_w8_a16.cpp` covered `T=96` but not `97`. It now carries `33/65/97` on both shapes. Against the unfixed dispatch all three fail on `[2048,4096]` and pass on `[2048,6144]`, and the new assertion names the cause:

```
W8_A16 LinearAdd [2048,4096] T=33: unexpected exception: w8 linear_add decode: kernel is specialised for K=6144
W8_A16 LinearAdd [2048,4096] T=65: unexpected exception: ...
W8_A16 LinearAdd [2048,4096] T=97: unexpected exception: ...
```

With the fix: `ctest` is **101/101**.

## Performance

RTX 3090, Qwen3.6-35B-A3B, rk8v4 KV, MTP3 + draft head, `ninfer_bench`:

| | before | after |
|---|---|---|
| tg512 decode | 280.38 tok/s @ 66.02% acceptance | **279.91 ± 0.42 tok/s @ 0.66019 acceptance** |

Within noise, and draft acceptance is bit-identical. The touched routes are prefill-tail only; decode (`T=1`, or `T=4` with MTP3) never reaches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTgRCa23NvNJ8nVTHuuXiH
