### PR TITLE
feat(ops): fail a round whose selected logit is not finite

### DIFF
--- a/include/ninfer/ops/sampling.h
+++ b/include/ninfer/ops/sampling.h
@@ -10,6 +10,15 @@
 
 namespace ninfer::ops {
 
+// Written to the token output instead of a vocabulary id when the selected token's own logit is
+// not finite. A diverged forward pass produces an all-NaN logits row, and because every ordering
+// comparison against NaN is false the reductions then return whatever index they started from,
+// after which top_k and the presence penalty walk the lowest token ids. That output reads like a
+// plausible sampling artefact rather than a fault, so the Ops emit this out-of-domain value and
+// let the runtime reject the round. The check is O(1) on the selected logit, not an exhaustive
+// scan: a row that still has a finite maximum samples normally.
+inline constexpr std::int32_t kSamplerNonFiniteToken = -1;
+
 // Counter-based RNG subkey. Distinct purposes keep draws at the same logical position separate.
 enum SamplePurpose : std::int32_t {
     kSamplePurposePrefill               = 0,

--- a/src/ops/kernel/sampling.cuh
+++ b/src/ops/kernel/sampling.cuh
@@ -58,8 +58,13 @@ __launch_bounds__(kSamplerBlock) __global__
             __syncthreads();
         }
         if (tid == 0) {
-            out[row] = red_idx[0];
-            if (cfg.token_counts != nullptr) { atomicAdd(&cfg.token_counts[red_idx[0]], 1); }
+            const int picked = red_idx[0];
+            if (!sampling_selected_logit_is_finite(logits, base, picked)) {
+                out[row] = kSamplerNonFiniteToken;
+            } else {
+                out[row] = picked;
+                if (cfg.token_counts != nullptr) { atomicAdd(&cfg.token_counts[picked], 1); }
+            }
         }
         return;
     }
@@ -98,6 +103,10 @@ __launch_bounds__(kSamplerBlock) __global__
             picked = cand_idx[j];
             break;
         }
+    }
+    if (!sampling_selected_logit_is_finite(logits, base, picked)) {
+        out[row] = kSamplerNonFiniteToken;
+        return;
     }
     out[row] = picked;
     if (cfg.token_counts != nullptr) { atomicAdd(&cfg.token_counts[picked], 1); }
@@ -209,8 +218,14 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void sampling_group_finalize_sa
         best = sampling_block_max_key(best, greedy_warp_keys);
         if (tid == 0) {
             const int picked = sampling_key_index(best);
-            out[col]         = picked;
-            if (cfg.token_counts != nullptr) { atomicAdd(&cfg.token_counts[picked], 1); }
+            // This kernel never sees the logits, so the winner's own ordered value carries the
+            // check. An empty key (0ull) decodes to NaN, which is the same rejection.
+            if (picked == INT_MAX || !sampling_value_is_finite(sampling_key_float(best))) {
+                out[col] = kSamplerNonFiniteToken;
+            } else {
+                out[col] = picked;
+                if (cfg.token_counts != nullptr) { atomicAdd(&cfg.token_counts[picked], 1); }
+            }
             workspace.group_done[col] = 0;
         }
         return;
@@ -281,15 +296,23 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void sampling_group_finalize_sa
         const float u     = sampling_uniform(cfg.seed, logical_positions[col], purpose, 0u);
         float acc         = 0.0f;
         int picked        = cand_idx[support - 1];
+        float picked_val  = cand_val[support - 1];
         for (int j = 0; j < support; ++j) {
             acc += prob[j];
             if (u < acc) {
-                picked = cand_idx[j];
+                picked     = cand_idx[j];
+                picked_val = cand_val[j];
                 break;
             }
         }
-        out[col] = picked;
-        if (cfg.token_counts != nullptr) { atomicAdd(&cfg.token_counts[picked], 1); }
+        // The candidate's own adjusted value stands in for the logit: this kernel is fed by the
+        // partial/group workspace and never receives the logits themselves.
+        if (!sampling_value_is_finite(picked_val)) {
+            out[col] = kSamplerNonFiniteToken;
+        } else {
+            out[col] = picked;
+            if (cfg.token_counts != nullptr) { atomicAdd(&cfg.token_counts[picked], 1); }
+        }
         workspace.group_done[col] = 0;
     }
 }

--- a/src/ops/kernel/sampling_device.cuh
+++ b/src/ops/kernel/sampling_device.cuh
@@ -23,6 +23,18 @@ using SamplingPartialSort =
 using SamplingGroupSort =
     cub::BlockMergeSort<unsigned long long, kSamplerGroupBlock, kSamplerGroupItemsPerThread>;
 
+// True when the value is a real number. Used to fail a round whose logits diverged instead of
+// sampling a plausible-looking token out of NaN (see kSamplerNonFiniteToken).
+__device__ __forceinline__ bool sampling_value_is_finite(float value) {
+    return value == value && value < CUDART_INF_F && value > -CUDART_INF_F;
+}
+
+__device__ __forceinline__ bool sampling_selected_logit_is_finite(const __nv_bfloat16* logits,
+                                                                  std::int64_t base,
+                                                                  std::int32_t index) {
+    return index >= 0 && sampling_value_is_finite(__bfloat162float(logits[base + index]));
+}
+
 struct SamplingKeyGreater {
     __device__ __forceinline__ bool operator()(unsigned long long a, unsigned long long b) const {
         return a > b;

--- a/src/ops/kernel/speculative_round.cuh
+++ b/src/ops/kernel/speculative_round.cuh
@@ -95,6 +95,18 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
             const int t_star = row_targets[a];
 
             for (int i = 0; i <= k; ++i) { row_tokens[i] = 0; }
+            // A diverged forward pass gives this column an all-NaN logit row, which makes the
+            // acceptance comparisons meaningless as well as the correction token. Fail the whole
+            // round rather than licensing plausible-looking garbage.
+            const std::int64_t t_star_base = static_cast<std::int64_t>(a) * physical_rows;
+            if (!sampling_selected_logit_is_finite(row_logits, t_star_base, t_star)) {
+                row_tokens[0]        = kSamplerNonFiniteToken;
+                licensed_counts[row] = 1;
+                accepted[row]        = 0;
+                anchors[row]         = kSamplerNonFiniteToken;
+                lengths[row] += 1;
+                return;
+            }
             for (int i = 0; i < a; ++i) { row_tokens[i] = row_drafts[i]; }
             row_tokens[a] = t_star;
 
@@ -180,6 +192,15 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
             const int tstar = tstar_sh;
             const int L     = L_sh;
             for (int i = 0; i <= k; ++i) { row_tokens[i] = 0; }
+            const std::int64_t tstar_base = static_cast<std::int64_t>(a) * physical_rows;
+            if (!sampling_selected_logit_is_finite(row_logits, tstar_base, tstar)) {
+                row_tokens[0]        = kSamplerNonFiniteToken;
+                licensed_counts[row] = 1;
+                accepted[row]        = 0;
+                anchors[row]         = kSamplerNonFiniteToken;
+                lengths[row]         = L + 1;
+                return;
+            }
             for (int i = 0; i < a; ++i) { row_tokens[i] = row_drafts[i]; }
             row_tokens[a]        = tstar;
             const int produced   = a + 1;
@@ -247,6 +268,15 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
         const int L     = L_sh;
 
         for (int i = 0; i <= k; ++i) { row_tokens[i] = 0; }
+        const std::int64_t tstar_base = static_cast<std::int64_t>(a) * physical_rows;
+        if (!sampling_selected_logit_is_finite(row_logits, tstar_base, tstar)) {
+            row_tokens[0]        = kSamplerNonFiniteToken;
+            licensed_counts[row] = 1;
+            accepted[row]        = 0;
+            anchors[row]         = kSamplerNonFiniteToken;
+            lengths[row]         = L + 1;
+            return;
+        }
         for (int i = 0; i < a; ++i) { row_tokens[i] = row_drafts[i]; }
         row_tokens[a] = tstar;
 
@@ -504,6 +534,10 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
             const int L = lengths[row];
             int a       = 0;
             int tstar   = 0;
+            // This kernel is fed by the partial/group workspace and never sees the logits, so the
+            // selected column's own normalized distribution carries the divergence check: NaN
+            // logits normalize to NaN probabilities.
+            float tstar_prob = 0.0f;
             for (int i = 0; i <= extent; ++i) {
                 const int n            = workspace.dist_support[i];
                 const int* dist_idx    = workspace.dist_idx + sampling_dist_offset(i, 0);
@@ -526,13 +560,24 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
                     const float ur = sampling_uniform(cfg.seed, L + i + 1,
                                                       kSamplePurposeSpeculativeCorrection, 0u);
                     tstar          = sampling_pick_from_support(dist_idx, dist_prob, n, d, ur);
+                    tstar_prob     = dist_prob[0];
                     break;
                 }
                 const float u =
                     sampling_uniform(cfg.seed, L + extent + 1, kSamplePurposeSpeculativeBonus, 0u);
-                tstar = sampling_pick_from_support(dist_idx, dist_prob, n, -1, u);
+                tstar      = sampling_pick_from_support(dist_idx, dist_prob, n, -1, u);
+                tstar_prob = dist_prob[0];
             }
             for (int i = 0; i <= k; ++i) { row_tokens[i] = 0; }
+            if (!sampling_value_is_finite(tstar_prob)) {
+                row_tokens[0]                         = kSamplerNonFiniteToken;
+                licensed_counts[row]                  = 1;
+                accepted[row]                         = 0;
+                anchors[row]                          = kSamplerNonFiniteToken;
+                lengths[row]                          = L + 1;
+                *workspace.speculative_finalize_count = 0;
+                return;
+            }
             for (int i = 0; i < a; ++i) { row_tokens[i] = row_drafts[i]; }
             row_tokens[a]        = tstar;
             const int produced   = a + 1;

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -10145,6 +10145,15 @@ void ProgramImplCore::enqueue_dflash_context_append(std::span<const std::uint32_
 
 void ProgramImplCore::validate_licensed_tokens(std::span<const TokenId> tokens) const {
     for (const TokenId token : tokens) {
+        if (token == ops::kSamplerNonFiniteToken) {
+            // The sampler refused to turn a non-finite logit row into a token id. Reaching here
+            // means the forward pass diverged, so say that rather than reporting a domain error:
+            // the alternative is streaming whatever the reductions make of NaN, which reads like
+            // ordinary output and hides the fault.
+            throw std::runtime_error(
+                "the forward pass produced non-finite logits (NaN or infinity); the sampler "
+                "refused to emit a token for this round");
+        }
         if (token < 0 || token >= TextConfig::token_domain) {
             throw std::runtime_error("target returned a token outside the 248077-token domain");
         }


### PR DESCRIPTION
## Problem

A diverged forward pass doesn't produce obvious garbage — it produces confident-looking text.

Every ordering comparison against NaN is false, so the sampler's reductions return whatever index they started from, and `top_k` plus the presence penalty then walk the lowest token ids in turn. With the Qwen3.6-35B-A3B artifact's non-thinking defaults (`top_k=20`, `presence_penalty=1.5`, `temperature=0.7`) an all-NaN logit row renders as exactly twenty distinct tokens:

```
43210/.-,+*)('&%$#"!4444444444444444444444444444...
```

That is token ids 19 down to 0 in GPT-2 byte order (`!`=0 … `4`=19), followed by an endless run of the last one. It reads like a sampling artefact, not a fault. It cost a full day of debugging to recognise as NaN — the actual cause was #22, an out-of-bounds read in the sm_86 W8 `linear_add` single-column tail.

Two tells that it is NaN rather than a flat distribution: `temperature=0` yields `!!!!!!` (argmax of an all-equal buffer), and two different seeds produce **byte-identical** output, which uniform sampling cannot do.

## Change

The Ops now write `kSamplerNonFiniteToken` (`-1`) instead of a vocabulary id when the selected token's own logit is not finite, and skip the token-count histogram for it so nothing indexes out of domain.

Covered: both single-block routes and both group-finalize routes in `sampling.cuh`, and all four commit sites in `speculative_round.cuh`. The two kernels fed from the partial/group workspace never receive the logits, so there the winner's own ordered key value (`sampling_key_float`) and the selected candidate's normalized probability carry the check.

`validate_licensed_tokens()` turns the sentinel into a named error instead of a domain error, so the failure says what happened:

```
[req 1] error the forward pass produced non-finite logits (NaN or infinity);
        the sampler refused to emit a token for this round
```

## Deliberate scope

- The check is **O(1) on the selected value**, not an exhaustive scan. A row that still has a finite maximum samples exactly as before. This catches catastrophic divergence, which is the case that produces plausible-looking gibberish.
- `ops::argmax` is deliberately untouched: its tiled route uses `out[t]` as running atomic-CAS state and reads `logits[base + current]`, so a sentinel there would corrupt the reduction. The round's *committed* tokens are guarded instead, which is where a bad token would otherwise reach the client.

## Testing

Verified by injecting an all-NaN hidden state on the real serving path (rk8v4 KV, MTP3, draft head, `temperature=0.7`, `/v1/responses`):

- at warmup the server refuses to start, naming the cause;
- on a live request the log reports the message above and the engine fails closed instead of streaming.

`ctest` is **101/101**.

## Performance

RTX 3090, Qwen3.6-35B-A3B, rk8v4 KV, MTP3 + draft head, `ninfer_bench`:

| | before | after |
|---|---|---|
| tg512 decode | 280.38 tok/s @ 66.02% acceptance | **279.91 ± 0.42 tok/s @ 0.66019 acceptance** |

Draft acceptance is bit-identical, which confirms the sampling path is unchanged for finite logits. The added cost is one extra logit load and one compare per committed token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTgRCa23NvNJ8nVTHuuXiH
